### PR TITLE
Allow starting a VM with cdrom attached

### DIFF
--- a/patches.qubes/stubdom-linux-0005.patch
+++ b/patches.qubes/stubdom-linux-0005.patch
@@ -186,21 +186,25 @@ HW42:
                  ioemu_nics++;
              }
          }
-@@ -1391,9 +1415,15 @@ static int libxl__build_device_model_arg
-                          "if=ide,index=%d,readonly=on,media=cdrom,id=ide-%i",
-                          disk, dev_number);
+@@ -1388,12 +1412,17 @@ static int libxl__build_device_model_arg
+
+             if (disks[i].is_cdrom) {
+                 drive = libxl__sprintf(gc,
+-                         "if=ide,index=%d,readonly=on,media=cdrom,id=ide-%i",
+-                         disk, dev_number);
++                         "if=ide,readonly=on,media=cdrom,id=ide-%i",
++                         dev_number);
  
 -                if (target_path)
 -                    drive = libxl__sprintf(gc, "%s,file=%s,format=%s",
 -                                           drive, target_path, format);
-+                if (target_path) {
-+                    if (b_info->stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX) {
++                if (b_info->stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX) {
++                    if (disks[i].format != LIBXL_DISK_FORMAT_EMPTY)
 +                        drive = libxl__sprintf(gc, "%s,file=/dev/xvd%c,format=host_device",
 +                                               drive, 'a' + disk);
-+                    } else {
-+                        drive = libxl__sprintf(gc, "%s,file=%s,format=%s",
-+                                               drive, target_path, format);
-+                    }
++                } else if (target_path) {
++                    drive = libxl__sprintf(gc, "%s,file=%s,format=%s",
++                                           drive, target_path, format);
 +                }
              } else {
                  /*

--- a/patches.qubes/stubdom-linux-libxl-do-not-force-qdisk-backend-for-cdrom.patch
+++ b/patches.qubes/stubdom-linux-libxl-do-not-force-qdisk-backend-for-cdrom.patch
@@ -1,0 +1,46 @@
+From d48fac7458e7a029c325e76ced028fd0b0afb44c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 28 Aug 2017 02:14:25 +0200
+Subject: [PATCH] libxl: do not force qdisk backend for cdrom
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+There is no qemu in dom0 in Qubes, every block device use vbd backend
+type and only then is appropriately handled by stubdomain.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libxl/libxl.c | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/tools/libxl/libxl.c b/tools/libxl/libxl.c
+index 814aa02..5cca657 100644
+--- a/tools/libxl/libxl.c
++++ b/tools/libxl/libxl.c
+@@ -2084,19 +2084,6 @@ int libxl__device_disk_setdefault(libxl__gc *gc, libxl_device_disk *disk,
+     rc = libxl__resolve_domid(gc, disk->backend_domname, &disk->backend_domid);
+     if (rc < 0) return rc;
+ 
+-    /* Force Qdisk backend for CDROM devices of guests with a device model. */
+-    if (disk->is_cdrom != 0 &&
+-        libxl__domain_type(gc, domid) == LIBXL_DOMAIN_TYPE_HVM &&
+-        libxl__device_model_version_running(gc, domid) !=
+-        LIBXL_DEVICE_MODEL_VERSION_NONE) {
+-        if (!(disk->backend == LIBXL_DISK_BACKEND_QDISK ||
+-              disk->backend == LIBXL_DISK_BACKEND_UNKNOWN)) {
+-            LOG(ERROR, "Backend for CD devices on HVM guests must be Qdisk");
+-            return ERROR_FAIL;
+-        }
+-        disk->backend = LIBXL_DISK_BACKEND_QDISK;
+-    }
+-
+     rc = libxl__device_disk_set_backend(gc, disk);
+     return rc;
+ }
+-- 
+2.9.5
+

--- a/patches.qubes/stubdom-linux-libxl-don-t-try-to-resolve-local-disk-path-with-stub.patch
+++ b/patches.qubes/stubdom-linux-libxl-don-t-try-to-resolve-local-disk-path-with-stub.patch
@@ -1,0 +1,36 @@
+From e8bc7a422c9a886cc3f37169d96903161e11b784 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 30 Aug 2017 01:55:01 +0200
+Subject: [PATCH] libxl: don't try to resolve local disk path with stubdomain
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+When device model is running in stubdomain, there is no sense in
+resolving disk path in dom0. In stubdomain, it will always be either
+/dev/xvd*, or appropriate FD in mini-os.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libxl/libxl_dm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/libxl/libxl_dm.c b/tools/libxl/libxl_dm.c
+index ad366a8..b9dbf5f 100644
+--- a/tools/libxl/libxl_dm.c
++++ b/tools/libxl/libxl_dm.c
+@@ -1352,7 +1352,7 @@ static int libxl__build_device_model_args_new(libxl__gc *gc,
+                         disks[i].vdev);
+                     continue;
+                 }
+-            } else {
++            } else if (!libxl_defbool_val(b_info->device_model_stubdomain)) {
+                 if (format == NULL) {
+                     LOG(WARN,
+                         "Unable to determine disk image format: %s\n"
+-- 
+2.9.5
+

--- a/series.conf
+++ b/series.conf
@@ -109,3 +109,4 @@ patches.qubes/stubdom-linux-fix-need-memory.patch
 patches.qubes/stubdom-linux-config-stubdom-mem.patch
 patches.qubes/stubdom-linux-libxl-suspend.patch
 patches.qubes/stubdom-linux-libxl-silence-dm_check_start.patch
+patches.qubes/stubdom-linux-libxl-do-not-force-qdisk-backend-for-cdrom.patch

--- a/series.conf
+++ b/series.conf
@@ -110,3 +110,4 @@ patches.qubes/stubdom-linux-config-stubdom-mem.patch
 patches.qubes/stubdom-linux-libxl-suspend.patch
 patches.qubes/stubdom-linux-libxl-silence-dm_check_start.patch
 patches.qubes/stubdom-linux-libxl-do-not-force-qdisk-backend-for-cdrom.patch
+patches.qubes/stubdom-linux-libxl-don-t-try-to-resolve-local-disk-path-with-stub.patch


### PR DESCRIPTION
There were a couple of checks in libxl preventing cdrom usage with qemu-xen in
linux-stubdom. Those patches removes the check. And most likely break
qemu-in-dom0 usage with cdrom, or at least make error messages for invalid
configuration much less informative. But we don't support qemu in dom0.

Fixes QubesOS/qubes-issues#2951