### PR TITLE
Archlinux template fixes for QubesOS 4.0

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -101,6 +101,8 @@ package() {
   rm -rf $pkgdir/etc/sysconfig
   rm -rf $pkgdir/etc/rc.d/init.d
 
+  rm -r "$pkgdir/var/run"
+
   ############ fixup files in /etc ############
 
   # udev

--- a/series-vm.conf
+++ b/series-vm.conf
@@ -1,4 +1,3 @@
-patches.qubes/xen-shared-loop-losetup.patch
 patches.qubes/xen-no-downloads.patch
 patches.qubes/xen-hotplug-external-store.patch
 patches.qubes/xen-tools-qubes-vm.patch
@@ -6,10 +5,4 @@ patches.qubes/vm-0001-hotplug-do-not-attempt-to-remove-containing-xenstore.patch
 patches.misc/libxc-fix-xc_gntshr_munmap-semantic.patch
 patches.misc/libvchan-Fix-cleanup-when-xc_gntshr_open-failed.patch
 patches.misc/0101-libvchan-create-xenstore-entries-in-one-transaction.patch
-patches.misc/0001-configure-Fix-when-no-libsystemd-compat-lib-are-avai.patch
-patches.misc/0001-tools-hotplug-Add-native-systemd-xendriverdomain.ser.patch
-patches.libxl/0001-libxl-trigger-attach-events-for-devices-attached-bef.patch
 patches.libxl/0001-tools-include-sys-sysmacros.h-on-Linux.patch
-patches.misc/0001-systemd-use-standard-dependencies-for-xendriverdomai.patch
-patches.misc/0001-libfsimage-replace-deprecated-readdir_r-with-readdir.patch
-patches.misc/0001-libxl-replace-deprecated-readdir_r-with-readdir.patch


### PR DESCRIPTION
I've just fixed the archlinux PKGBUILD script and removed the missing (obsolete?) Xen patches. The problem is that I don't know that much about Xen (and consequently what exactly I am doing here ) :smile: ...

It seems that the archlinux build uses [`series-vm.conf`](https://github.com/QubesOS/qubes-vmm-xen/blob/xen-4.8/series-vm.conf) patches while fedora uses the much bigger [`series.conf`](https://github.com/QubesOS/qubes-vmm-xen/blob/xen-4.8/series.conf) patchlist... So at first I attempted to use it in the archlinux build as well. That resulted in strange errors like `make[7]: *** No rule to make target '/usr/share/ipxe/10ec8139.rom', needed by 'roms.inc'.  Stop.`.  After a while messing around and trying to understand what the issues were, I decided to try using `series-vm.conf` with the missing patches removed and see what happened. 

To my surprise it worked - the package compiles for archlinux and the resulting template is installable and seems usable. I noticed a slight issue - when starting the archlinux VMs, a black screen with some initialization/bios related text is briefly shown before the VM is fully started. I'll try to grab a screenshot next time I reboot in 4.0  - I'm still using 3.2 on the same machine for day-to-day stuff so debugging will be slow... Also there were some issues with clean VM shutdown, but that may be unrelated. In any case, any help and knowhow is appreciated. 

2017-11-19 edit: I've been using this for a few weeks now and haven't noticed any archlinux-specific bugs, so maybe the changes are OK.