### PR TITLE
Backport elfloader fix to detect non PVH capable kernels

### DIFF
--- a/patches.misc/96edb111-libxc-panic-when-trying-to-create-a-PVH-guest-withou.patch
+++ b/patches.misc/96edb111-libxc-panic-when-trying-to-create-a-PVH-guest-withou.patch
@@ -1,0 +1,44 @@
+From 96edb111dde9ad7698a6fc2eaf2e49db507b0ed4 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Fri, 6 Oct 2017 14:51:59 +0100
+Subject: [PATCH] libxc: panic when trying to create a PVH guest without kernel
+ support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Previously when trying to boot a PV capable but not PVH capable kernel
+inside of a PVH container xc_dom_guest_type would succeed and return a
+PV guest type, which would lead to failures later on in the build
+process.
+
+Instead provide a clear error message when trying to create a PVH
+guest using a kernel that doesn't support PVH.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Ian Jackson <ian.jackson@eu.citrix.com>
+---
+ tools/libxc/xc_dom_elfloader.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/tools/libxc/xc_dom_elfloader.c b/tools/libxc/xc_dom_elfloader.c
+index 62d421a5e3..568d7f370c 100644
+--- a/tools/libxc/xc_dom_elfloader.c
++++ b/tools/libxc/xc_dom_elfloader.c
+@@ -59,6 +59,13 @@ static char *xc_dom_guest_type(struct xc_dom_image *dom,
+     if ( dom->container_type == XC_DOM_HVM_CONTAINER &&
+          dom->parms.phys_entry != UNSET_ADDR32 )
+         return "hvm-3.0-x86_32";
++    if ( dom->container_type == XC_DOM_HVM_CONTAINER )
++    {
++        xc_dom_panic(dom->xch, XC_INVALID_KERNEL,
++                     "%s: image not capable of booting inside a HVM container",
++                     __FUNCTION__);
++        return "xen-3.0-unknown";
++    }
+ 
+     switch ( machine )
+     {
+-- 
+2.15.1
+

--- a/patches.misc/libxc-panic-when-trying-to-create-a-PVH-guest-withou.patch
+++ b/patches.misc/libxc-panic-when-trying-to-create-a-PVH-guest-withou.patch
@@ -1,6 +1,6 @@
-From 96edb111dde9ad7698a6fc2eaf2e49db507b0ed4 Mon Sep 17 00:00:00 2001
-From: Roger Pau Monne <roger.pau@citrix.com>
-Date: Fri, 6 Oct 2017 14:51:59 +0100
+From 504f7159e595c8e2f15c0bec91be049e3f13707b Mon Sep 17 00:00:00 2001
+From: Simon Gaiser <simon@invisiblethingslab.com>
+Date: Fri, 19 Jan 2018 06:31:02 +0100
 Subject: [PATCH] libxc: panic when trying to create a PVH guest without kernel
  support
 MIME-Version: 1.0
@@ -15,17 +15,18 @@ process.
 Instead provide a clear error message when trying to create a PVH
 guest using a kernel that doesn't support PVH.
 
-Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
-Acked-by: Ian Jackson <ian.jackson@eu.citrix.com>
+Based on upstream commit 96edb111dde9ad7698a6fc2eaf2e49db507b0ed4 from
+Roger Pau Monné <roger.pau@citrix.com>. Modified to immediately return
+an error.
 ---
- tools/libxc/xc_dom_elfloader.c | 7 +++++++
- 1 file changed, 7 insertions(+)
+ tools/libxc/xc_dom_elfloader.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
 
 diff --git a/tools/libxc/xc_dom_elfloader.c b/tools/libxc/xc_dom_elfloader.c
-index 62d421a5e3..568d7f370c 100644
+index 62d421a5e3..b67b95eb19 100644
 --- a/tools/libxc/xc_dom_elfloader.c
 +++ b/tools/libxc/xc_dom_elfloader.c
-@@ -59,6 +59,13 @@ static char *xc_dom_guest_type(struct xc_dom_image *dom,
+@@ -59,6 +59,14 @@ static char *xc_dom_guest_type(struct xc_dom_image *dom,
      if ( dom->container_type == XC_DOM_HVM_CONTAINER &&
           dom->parms.phys_entry != UNSET_ADDR32 )
          return "hvm-3.0-x86_32";
@@ -34,11 +35,21 @@ index 62d421a5e3..568d7f370c 100644
 +        xc_dom_panic(dom->xch, XC_INVALID_KERNEL,
 +                     "%s: image not capable of booting inside a HVM container",
 +                     __FUNCTION__);
-+        return "xen-3.0-unknown";
++        errno = EINVAL;
++        return NULL;
 +    }
  
      switch ( machine )
      {
+@@ -188,6 +196,8 @@ static elf_errorstatus xc_dom_parse_elf_kernel(struct xc_dom_image *dom)
+     dom->kernel_seg.vend   = dom->parms.virt_kend;
+ 
+     dom->guest_type = xc_dom_guest_type(dom, elf);
++    if (dom->guest_type == NULL)
++        return -EINVAL;
+     DOMPRINTF("%s: %s: 0x%" PRIx64 " -> 0x%" PRIx64 "",
+               __FUNCTION__, dom->guest_type,
+               dom->kernel_seg.vstart, dom->kernel_seg.vend);
 -- 
 2.15.1
 

--- a/series.conf
+++ b/series.conf
@@ -9,7 +9,7 @@ patches.misc/0001-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
 
 # backports
 patches.misc/0001-libxl-add-more-cpuid-flags-handling.patch
-patches.misc/96edb111-libxc-panic-when-trying-to-create-a-PVH-guest-withou.patch
+patches.misc/libxc-panic-when-trying-to-create-a-PVH-guest-withou.patch
 
 # Security fixes
 patches.security/xsa231-4.9.patch

--- a/series.conf
+++ b/series.conf
@@ -9,6 +9,7 @@ patches.misc/0001-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
 
 # backports
 patches.misc/0001-libxl-add-more-cpuid-flags-handling.patch
+patches.misc/96edb111-libxc-panic-when-trying-to-create-a-PVH-guest-withou.patch
 
 # Security fixes
 patches.security/xsa231-4.9.patch


### PR DESCRIPTION
QubesOS/qubes-issues#3474

---

With this change the message is a good bit clearer, although the "No such file or directory" is still a bit irritating.


    2018-01-18 20:42:47.735+0000: xc: panic: xc_dom_elfloader.c:66: xc_dom_guest_type: image not capable of booting inside a HVM container: Invalid kernel
    2018-01-18 20:42:47.735+0000: xc: panic: xc_dom_core.c:734: xc_dom_set_arch_hooks: not found (type xen-3.0-unknown): Invalid kernel
    2018-01-18 20:42:47.735+0000: xc: panic: xc_dom_core.c:944: xc_dom_mem_init: arch hooks not set: Internal error
    2018-01-18 20:42:47.735+0000: libxl: libxl_dom.c:649:libxl__build_dom: xc_dom_mem_init failed: No such file or directory
    2018-01-18 20:42:47.741+0000: libxl: libxl_create.c:1266:domcreate_rebuild_done: cannot (re-)build domain: -3