### PR TITLE
Build Qubes Xen package only for dom0 Fedora and use upstream for VM

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -2,7 +2,6 @@ ifeq ($(PACKAGE_SET),dom0)
   RPM_SPEC_FILES := xen.spec
 
 else ifeq ($(PACKAGE_SET),vm)
-  RPM_SPEC_FILES := xen.spec
   ARCH_BUILD_DIRS := archlinux
 
   ifneq ($(filter $(DISTRIBUTION), debian qubuntu),)


### PR DESCRIPTION
QubesOS/qubes-issues#3945