### PR TITLE
rpm: Be consistent with EFI binary name

### DIFF
--- a/xen.spec.in
+++ b/xen.spec.in
@@ -748,9 +748,9 @@ EFI_DIR=$(efibootmgr -v 2>/dev/null | awk '
 # FAT (on ESP) does not support symlinks
 # override the file on purpose
 if [ -d "/boot/efi${EFI_DIR}" ]; then
-  cp -pf /boot/efi/EFI/qubes/xen-%{version}.efi /boot/efi${EFI_DIR}/xen.efi
+  cp -pf /boot/efi/EFI/qubes/xen-%{version}-%{release}.efi /boot/efi${EFI_DIR}/xen.efi
 else
-  cp -pf /boot/efi/EFI/qubes/xen-%{version}.efi /boot/efi/EFI/qubes/xen.efi
+  cp -pf /boot/efi/EFI/qubes/xen-%{version}-%{release}.efi /boot/efi/EFI/qubes/xen.efi
 fi
 %endif
 


### PR DESCRIPTION
Prior to this commit, Xen EFI binary would be installed into the EFI partition as "xen-4.8.5-4.fc25.efi", whereas prior to commit abf64bdeb9 ("rpm: export the same env variable during build and install"), the file name did not have the package release suffix (i.e., "-4.fc25"). The existence of the package release suffix in the file name causes the RPM installation scripts to fail to copy the binary to xen.efi in the EFI partition.

To avoid the aforementioned issue, this commit uses the release provided by RPM in the hypervisor package's post-installation script for the naming of the EFI binary as well.