### PR TITLE
Add Undervolt MSRs to wrmsr function.

### DIFF
--- a/patch-intel-undervolt.patch
+++ b/patch-intel-undervolt.patch
@@ -1,0 +1,33 @@
+Index: xen-4.8.5/xen/arch/x86/traps.c
+===================================================================
+--- xen-4.8.5.orig/xen/arch/x86/traps.c
++++ xen-4.8.5/xen/arch/x86/traps.c
+@@ -2684,6 +2684,15 @@ static int priv_op_write_msr(unsigned in
+             goto invalid;
+         return X86EMUL_OKAY;
+ 
++    // To-Do, restrict this to dom0 only
++    case MSR_IA32_VOLTAGE_OFFSET:
++    case MSR_IA32_TEMP_CONTROL:
++        if ( boot_cpu_data.x86_vendor != X86_VENDOR_INTEL )
++            break;
++        if ( wrmsr_safe(reg, val) == 0 )
++            return X86EMUL_OKAY;
++        break;
++
+     case MSR_IA32_MISC_ENABLE:
+         if ( rdmsr_safe(reg, temp) )
+             break;
+Index: xen-4.8.5/xen/include/asm-x86/msr-index.h
+===================================================================
+--- xen-4.8.5.orig/xen/include/asm-x86/msr-index.h
++++ xen-4.8.5/xen/include/asm-x86/msr-index.h
+@@ -346,6 +346,8 @@
+ #define MSR_IA32_THERM_INTERRUPT	0x0000019b
+ #define MSR_IA32_THERM_STATUS		0x0000019c
+ #define MSR_IA32_MISC_ENABLE		0x000001a0
++#define MSR_IA32_VOLTAGE_OFFSET		0x00000150
++#define MSR_IA32_TEMP_CONTROL		0x000001a2
+ #define MSR_IA32_MISC_ENABLE_PERF_AVAIL   (1<<7)
+ #define MSR_IA32_MISC_ENABLE_BTS_UNAVAIL  (1<<11)
+ #define MSR_IA32_MISC_ENABLE_PEBS_UNAVAIL (1<<12)

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -217,6 +217,7 @@ Patch910: patch-vm-0001-hotplug-do-not-attempt-to-remove-containing-xenstore.pat
 Patch911: patch-xen-hotplug-qubesdb-update.patch
 Patch912: patch-tools-hotplug-drop-perl-usage-in-locking-mechanism.patch
 Patch913: patch-tools-xenconsole-replace-ESC-char-on-xenconsole-outp.patch
+Patch914: patch-intel-undervolt.patch
 
 # python3
 Patch1001: patch-0001-python-check-return-value-of-PyErr_NewException.patch
@@ -300,10 +301,6 @@ BuildRequires: checkpolicy m4
 %if %build_crosshyp
 # cross compiler for building 64-bit hypervisor on ix86
 BuildRequires: gcc-x86_64-linux-gnu
-%endif
-# gcc with BTI mitigation, for dom0 build
-%if 0%{?fedora} == 25
-BuildRequires: gcc >= 6.4.1-1.qubes1
 %endif
 Requires: bridge-utils
 %if 0%{?fedora} >= 29


### PR DESCRIPTION
Allows Undervolt MSRs to be witten to.

Specifically Voltage Offset (msr 0x150) and Throttle Temperature Control (msr 0x1a2), this allows people running on Laptops to Undervolt running Qubes.

**NOTE: We need to have a discussion about Security, these MSRs should only be writable from dom0!**

I've tested successfully with an i7-8550U (Huawei Matebook X Pro)