### PR TITLE
Backport: Apply fixes for framebuffer placed over 4GB

### DIFF
--- a/patch-0001-bitmap-fix-bitmap_fill-with-zero-sized-bitmap.patch
+++ b/patch-0001-bitmap-fix-bitmap_fill-with-zero-sized-bitmap.patch
@@ -1,0 +1,38 @@
+From 93df28be2d4f620caf18109222d046355ac56327 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 13 May 2019 10:12:00 +0200
+Subject: [PATCH 1/4] bitmap: fix bitmap_fill with zero-sized bitmap
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+When bitmap_fill(..., 0) is called, do not try to write anything. Before
+this patch, it tried to write almost LONG_MAX, surely overwriting
+something.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/include/xen/bitmap.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/xen/include/xen/bitmap.h b/xen/include/xen/bitmap.h
+index fe3c720e82..0430c1ce2a 100644
+--- a/xen/include/xen/bitmap.h
++++ b/xen/include/xen/bitmap.h
+@@ -126,6 +126,8 @@ static inline void bitmap_fill(unsigned long *dst, int nbits)
+ 	size_t nlongs = BITS_TO_LONGS(nbits);
+ 
+ 	switch (nlongs) {
++	case 0:
++		break;
+ 	default:
+ 		memset(dst, -1, (nlongs - 1) * sizeof(unsigned long));
+ 		/* fall through */
+-- 
+2.20.1
+

--- a/patch-0002-drivers-video-drop-unused-limits.patch
+++ b/patch-0002-drivers-video-drop-unused-limits.patch
@@ -1,0 +1,37 @@
+From 343459e34a6d32ba44a21f8b8fe4c1f69b1714c2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 13 May 2019 10:12:56 +0200
+Subject: [PATCH 2/4] drivers/video: drop unused limits
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+MAX_BPP, MAX_FONT_W, MAX_FONT_H are not used in the code at all.
+
+Suggested-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Acked-by: Andrew Cooper <andrew.cooper3@citrix.com>
+---
+ xen/drivers/video/lfb.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/xen/drivers/video/lfb.c b/xen/drivers/video/lfb.c
+index d0c8c492b0..0475a68296 100644
+--- a/xen/drivers/video/lfb.c
++++ b/xen/drivers/video/lfb.c
+@@ -12,9 +12,6 @@
+ 
+ #define MAX_XRES 1900
+ #define MAX_YRES 1200
+-#define MAX_BPP 4
+-#define MAX_FONT_W 8
+-#define MAX_FONT_H 16
+ 
+ struct lfb_status {
+     struct lfb_prop lfbp;
+-- 
+2.20.1
+

--- a/patch-0003-drivers-video-drop-framebuffer-size-constraints.patch
+++ b/patch-0003-drivers-video-drop-framebuffer-size-constraints.patch
@@ -1,0 +1,55 @@
+From 19600eb75aa9b1df3e4b0a4e55a5d08b957e1fd9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 13 May 2019 10:13:24 +0200
+Subject: [PATCH 3/4] drivers/video: drop framebuffer size constraints
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+The limit 1900x1200 do not match real world devices (1900 looks like a
+typo, should be 1920). But in practice the limits are arbitrary and do
+not serve any real purpose. As discussed in "Increase framebuffer size
+to todays standards" thread, drop them completely.
+
+This fixes graphic console on device with 3840x2160 native resolution.
+
+Suggested-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Acked-by: Andrew Cooper <andrew.cooper3@citrix.com>
+---
+ xen/drivers/video/lfb.c | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/xen/drivers/video/lfb.c b/xen/drivers/video/lfb.c
+index 0475a68296..5022195ae5 100644
+--- a/xen/drivers/video/lfb.c
++++ b/xen/drivers/video/lfb.c
+@@ -10,9 +10,6 @@
+ #include "lfb.h"
+ #include "font.h"
+ 
+-#define MAX_XRES 1900
+-#define MAX_YRES 1200
+-
+ struct lfb_status {
+     struct lfb_prop lfbp;
+ 
+@@ -146,13 +143,6 @@ void lfb_carriage_return(void)
+ 
+ int __init lfb_init(struct lfb_prop *lfbp)
+ {
+-    if ( lfbp->width > MAX_XRES || lfbp->height > MAX_YRES )
+-    {
+-        printk(XENLOG_WARNING "Couldn't initialize a %ux%u framebuffer early.\n",
+-               lfbp->width, lfbp->height);
+-        return -EINVAL;
+-    }
+-
+     lfb.lfbp = *lfbp;
+ 
+     lfb.lbuf = xmalloc_bytes(lfb.lfbp.bytes_per_line);
+-- 
+2.20.1

--- a/patch-0004-drivers-video-use-vlfb_info-consistently.patch
+++ b/patch-0004-drivers-video-use-vlfb_info-consistently.patch
@@ -1,0 +1,36 @@
+From 1e31c150f6b0efac59df1824e9881b3eb00b01b5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 13 May 2019 10:14:02 +0200
+Subject: [PATCH 4/4] drivers/video: use vlfb_info consistently
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+vlfb_info is an alias for vga_console_info.u.vesa_lfb, so this change is
+purely cosmetic. But using the same name helps reading the code.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Acked-by: Andrew Cooper <andrew.cooper3@citrix.com>
+---
+ xen/drivers/video/vesa.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xen/drivers/video/vesa.c b/xen/drivers/video/vesa.c
+index c92497e0bc..26d4962b0e 100644
+--- a/xen/drivers/video/vesa.c
++++ b/xen/drivers/video/vesa.c
+@@ -44,7 +44,7 @@ void __init vesa_early_init(void)
+ {
+     unsigned int vram_vmode;
+ 
+-    vga_compat = !(vga_console_info.u.vesa_lfb.gbl_caps & 2);
++    vga_compat = !(vlfb_info.gbl_caps & 2);
+ 
+     if ( (vlfb_info.bits_per_pixel < 8) || (vlfb_info.bits_per_pixel > 32) )
+         return;
+-- 
+2.20.1
+

--- a/patch-0005-video-fix-handling-framebuffer-located-above-4GB.patch
+++ b/patch-0005-video-fix-handling-framebuffer-located-above-4GB.patch
@@ -1,0 +1,129 @@
+From 9cf11fdcd91ff8e9cd038f8336cf21f0701e8b7b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Fri, 17 May 2019 14:48:23 +0200
+Subject: [PATCH] video: fix handling framebuffer located above 4GB
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+On some machines (for example Thinkpad P52), UEFI GOP reports
+framebuffer located above 4GB (0x4000000000 on that machine). This
+address does not fit in {xen,dom0}_vga_console_info.u.vesa_lfb.lfb_base
+field, which is 32bit. The overflow here cause all kind of memory
+corruption when anything tries to write something on the screen,
+starting with zeroing the whole framebuffer in vesa_init().
+
+Fix this similar to how it's done in Linux: add ext_lfb_base field at
+the end of the structure, to hold upper 32bits of the address. Since the
+field is added at the end of the structure, it will work with older
+Linux versions too (other than using possibly truncated address - no
+worse than without this change). Thanks to ABI containing size of the
+structure (start_info.console.dom0.info_size), Linux can detect when
+this field is present and use it appropriately then.
+
+Since this change public interface and use __XEN_INTERFACE_VERSION__,
+bump __XEN_LATEST_INTERFACE_VERSION__.
+
+Note: if/when backporting this change to Xen <= 4.12, #if in xen.h needs
+to be extended with " || defined(__XEN__)".
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Reviewed-by: Juergen Gross <jgross@suse.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/efi/efi-boot.h     |  1 +
+ xen/drivers/video/vesa.c        | 14 +++++++++-----
+ xen/include/public/xen-compat.h |  2 +-
+ xen/include/public/xen.h        |  5 +++++
+ 4 files changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/xen/arch/x86/efi/efi-boot.h b/xen/arch/x86/efi/efi-boot.h
+index 5789d2cb70..7a13a30bc0 100644
+--- a/xen/arch/x86/efi/efi-boot.h
++++ b/xen/arch/x86/efi/efi-boot.h
+@@ -550,6 +550,7 @@ static void __init efi_arch_video_init(EFI_GRAPHICS_OUTPUT_PROTOCOL *gop,
+         vga_console_info.u.vesa_lfb.bytes_per_line =
+             (mode_info->PixelsPerScanLine * bpp + 7) >> 3;
+         vga_console_info.u.vesa_lfb.lfb_base = gop->Mode->FrameBufferBase;
++        vga_console_info.u.vesa_lfb.ext_lfb_base = gop->Mode->FrameBufferBase >> 32;
+         vga_console_info.u.vesa_lfb.lfb_size =
+             (gop->Mode->FrameBufferSize + 0xffff) >> 16;
+     }
+diff --git a/xen/drivers/video/vesa.c b/xen/drivers/video/vesa.c
+index 26d4962b0e..fd2cb1312d 100644
+--- a/xen/drivers/video/vesa.c
++++ b/xen/drivers/video/vesa.c
+@@ -40,6 +40,11 @@ static int __init parse_font_height(const char *s)
+ }
+ custom_param("font", parse_font_height);
+ 
++static inline paddr_t lfb_base(void)
++{
++    return ((paddr_t)vlfb_info.ext_lfb_base << 32) | vlfb_info.lfb_base;
++}
++
+ void __init vesa_early_init(void)
+ {
+     unsigned int vram_vmode;
+@@ -97,15 +102,14 @@ void __init vesa_init(void)
+     lfbp.text_columns = vlfb_info.width / font->width;
+     lfbp.text_rows = vlfb_info.height / font->height;
+ 
+-    lfbp.lfb = lfb = ioremap(vlfb_info.lfb_base, vram_remap);
++    lfbp.lfb = lfb = ioremap(lfb_base(), vram_remap);
+     if ( !lfb )
+         return;
+ 
+     memset(lfb, 0, vram_remap);
+ 
+-    printk(XENLOG_INFO "vesafb: framebuffer at %#x, mapped to 0x%p, "
+-           "using %uk, total %uk\n",
+-           vlfb_info.lfb_base, lfb,
++    printk(XENLOG_INFO "vesafb: framebuffer at 0x%" PRIpaddr ", mapped to 0x%p, using %uk, total %uk\n",
++           lfb_base(), lfb,
+            vram_remap >> 10, vram_total >> 10);
+     printk(XENLOG_INFO "vesafb: mode is %dx%dx%u, linelength=%d, font %ux%u\n",
+            vlfb_info.width, vlfb_info.height,
+@@ -167,7 +171,7 @@ void __init vesa_mtrr_init(void)
+ 
+     /* Try and find a power of two to add */
+     do {
+-        rc = mtrr_add(vlfb_info.lfb_base, size_total, type, 1);
++        rc = mtrr_add(lfb_base(), size_total, type, 1);
+         size_total >>= 1;
+     } while ( (size_total >= PAGE_SIZE) && (rc == -EINVAL) );
+ }
+diff --git a/xen/include/public/xen-compat.h b/xen/include/public/xen-compat.h
+index 6fabca1889..6708132394 100644
+--- a/xen/include/public/xen-compat.h
++++ b/xen/include/public/xen-compat.h
+@@ -27,7 +27,7 @@
+ #ifndef __XEN_PUBLIC_XEN_COMPAT_H__
+ #define __XEN_PUBLIC_XEN_COMPAT_H__
+ 
+-#define __XEN_LATEST_INTERFACE_VERSION__ 0x00040800
++#define __XEN_LATEST_INTERFACE_VERSION__ 0x00040d00
+ 
+ #if defined(__XEN__) || defined(__XEN_TOOLS__)
+ /* Xen is built with matching headers and implements the latest interface. */
+diff --git a/xen/include/public/xen.h b/xen/include/public/xen.h
+index ccdffc0ad1..cb2917e74b 100644
+--- a/xen/include/public/xen.h
++++ b/xen/include/public/xen.h
+@@ -922,6 +922,11 @@ typedef struct dom0_vga_console_info {
+             uint32_t gbl_caps;
+             /* Mode attributes (offset 0x0, VESA command 0x4f01). */
+             uint16_t mode_attrs;
++            uint16_t pad;
++#endif
++#if __XEN_INTERFACE_VERSION__ >= 0x00040d00 || defined(__XEN__)
++            /* high 32 bits of lfb_base */
++            uint32_t ext_lfb_base;
+ #endif
+         } vesa_lfb;
+     } u;
+-- 
+2.20.1

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -182,6 +182,11 @@ Patch624: patch-qemu-docs-utf8.patch
 Patch625: patch-minios-remove-net-device-instead-of-preparing-for-re.patch
 Patch626: patch-xenconsole-sanitize-ESC-in-log.patch
 Patch627: patch-qemu-keyboard-leds.patch
+Patch629: patch-0001-bitmap-fix-bitmap_fill-with-zero-sized-bitmap.patch
+Patch630: patch-0002-drivers-video-drop-unused-limits.patch
+Patch631: patch-0003-drivers-video-drop-framebuffer-size-constraints.patch
+Patch632: patch-0004-drivers-video-use-vlfb_info-consistently.patch
+Patch633: patch-0005-video-fix-handling-framebuffer-located-above-4GB.patch
 
 # GCC7 fixes
 Patch701: patch-0001-tools-include-sys-sysmacros.h-on-Linux.patch


### PR DESCRIPTION
Backport the changes made in xen-4.12 by @marmarek. Hopefully this will fix https://github.com/QubesOS/qubes-issues/issues/5074. 

vmm-xen compiles fine. Currently compiling and testing the whole qubes install. 

commit: 35cbeb3f7d316fedf26c1069ae39b61400564018 from branch xen-4.12