### PR TITLE
add patch to additional support in ACPI builder SLIC and OEM installs

### DIFF
--- a/patch-xen-acpi-slic-support.patch
+++ b/patch-xen-acpi-slic-support.patch
@@ -1,0 +1,191 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Additional support in ACPI builder to support SLIC and OEM installs.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+In order to use Windows OEM install media, the SLIC table must be passed to a
+guest. In addition all the OEM table IDs must match the SLIC or Windows will
+think it is invalid and the install ends up unactivated.
+
+NOTE: The DSDT does not get updated. This was the same in the original patch.
+Not sure why that is but it is being left that way for now since it works w/o
+it.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Ported from qemu-acpi-tables.patch by:
+Ross Philipson, philipsonr@ainfosec.com, 05/05/2015
+
+Updated for Xen 4.8 and 4.9.
+
+################################################################################
+REMOVAL 
+################################################################################
+Never.
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+None.
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+
+################################################################################
+PATCHES 
+################################################################################
+--- a/tools/libacpi/build.c
++++ b/tools/libacpi/build.c
+@@ -340,6 +340,66 @@ static int construct_passthrough_tables(
+     return nr_added;
+ }
+ 
++static void fixup_headers(struct acpi_header *dest, struct acpi_header *src)
++{
++    char bounce[9];
++
++    if (dest == src)
++        return;
++
++    memset(bounce, 0, 9);
++    memcpy(bounce, dest->oem_id, 6);
++    printf("  Overwriting '%s'   with ", bounce);
++    memset(bounce, 0, 9);
++    memcpy(bounce, src->oem_id, 6);
++    printf("'%s'   in ", bounce);
++    printf("%c%c%c%c's OEM_ID\n",
++           ((char*)(&dest->signature))[0],
++           ((char*)(&dest->signature))[1],
++           ((char*)(&dest->signature))[2],
++           ((char*)(&dest->signature))[3]);
++
++
++    memcpy(dest->oem_id, src->oem_id, 6);
++
++    memset(bounce, 0, 9);
++    memcpy(bounce, dest->oem_table_id, 8);
++    printf("  Overwriting '%s' with ", bounce);
++    memset(bounce, 0, 9);
++    memcpy(bounce, src->oem_table_id, 8);
++    printf("'%s' in ", bounce);
++    printf("%c%c%c%c's OEM_TABLE_ID\n",
++           ((char*)(&dest->signature))[0],
++           ((char*)(&dest->signature))[1],
++           ((char*)(&dest->signature))[2],
++           ((char*)(&dest->signature))[3]);
++
++
++    memcpy(dest->oem_table_id, src->oem_table_id, 8);
++    set_checksum(dest, offsetof(struct acpi_header, checksum), dest->length);
++}
++
++static int is_slic(struct acpi_header *table)
++{
++    printf("  Table (%c%c%c%c) is ",
++           ((char*)(&table->signature))[0],
++           ((char*)(&table->signature))[1],
++           ((char*)(&table->signature))[2],
++           ((char*)(&table->signature))[3]);
++
++
++    if ( ( ((char*)(&table->signature))[0] == 'S' ) &&
++         ( ((char*)(&table->signature))[1] == 'L' ) &&
++         ( ((char*)(&table->signature))[2] == 'I' ) &&
++         ( ((char*)(&table->signature))[3] == 'C' ) ) {
++        printf("SLIC\n");
++        return 1;
++    }
++
++    printf ("NOT SLIC\n");
++    return 0;
++}
++
+ static int construct_secondary_tables(struct acpi_ctxt *ctxt,
+                                       unsigned long *table_ptrs,
+                                       struct acpi_config *config,
+@@ -515,6 +575,8 @@ int acpi_build_tables(struct acpi_ctxt *
+     unsigned long        secondary_tables[ACPI_MAX_SECONDARY_TABLES];
+     int                  nr_secondaries, i;
+     unsigned int         fadt_size;
++    struct acpi_header  *slic_header = NULL;
++    int                  needs_id_fixup = 0;
+ 
+     acpi_info = (struct acpi_info *)config->infop;
+     memset(acpi_info, 0, sizeof(*acpi_info));
+@@ -634,6 +696,27 @@ int acpi_build_tables(struct acpi_ctxt *
+     if ( nr_secondaries < 0 )
+         goto oom;
+ 
++    /* We can only have a SLIC if it was passed through. */
++    if ( config->pt.addr ) {
++        /* Check to see if one of the secondary tables is a SLIC. */
++        for (i = 0; i < nr_secondaries; i++) {
++            if (is_slic((struct acpi_header *)secondary_tables[i])) {
++                slic_header = (struct acpi_header *)secondary_tables[i];
++                needs_id_fixup = 1;
++                break;
++            }
++        }
++    }
++
++    /* If we have a SLIC, patch up the other tables to match it. */
++    if (needs_id_fixup) {
++        for (i = 0; i < nr_secondaries; i++) {
++            fixup_headers((struct acpi_header *)secondary_tables[i], slic_header);
++        }
++        fixup_headers(&fadt_10->header, slic_header);
++        fixup_headers(&fadt->header, slic_header);
++    }
++
+     xsdt = ctxt->mem_ops.alloc(ctxt, sizeof(struct acpi_20_xsdt) + 
+                                sizeof(uint64_t) * nr_secondaries,
+                                16);
+@@ -643,9 +726,13 @@ int acpi_build_tables(struct acpi_ctxt *
+     for ( i = 0; secondary_tables[i]; i++ )
+         xsdt->entry[i+1] = secondary_tables[i];
+     xsdt->header.length = sizeof(struct acpi_header) + (i+1)*sizeof(uint64_t);
+-    set_checksum(xsdt,
+-                 offsetof(struct acpi_header, checksum),
+-                 xsdt->header.length);
++    if (needs_id_fixup) {
++        fixup_headers(&xsdt->header, slic_header);
++    } else {
++        set_checksum(xsdt,
++                     offsetof(struct acpi_header, checksum),
++                     xsdt->header.length);
++    }
+ 
+     rsdt = ctxt->mem_ops.alloc(ctxt, sizeof(struct acpi_20_rsdt) +
+                                sizeof(uint32_t) * nr_secondaries,
+@@ -656,9 +743,13 @@ int acpi_build_tables(struct acpi_ctxt *
+     for ( i = 0; secondary_tables[i]; i++ )
+         rsdt->entry[i+1] = secondary_tables[i];
+     rsdt->header.length = sizeof(struct acpi_header) + (i+1)*sizeof(uint32_t);
+-    set_checksum(rsdt,
+-                 offsetof(struct acpi_header, checksum),
+-                 rsdt->header.length);
++    if (needs_id_fixup) {
++        fixup_headers(&rsdt->header, slic_header);
++    } else {
++        set_checksum(rsdt,
++                     offsetof(struct acpi_header, checksum),
++                     rsdt->header.length);
++    }
+ 
+     /*
+      * Fill in low-memory data structures: acpi_info and RSDP.
+@@ -668,6 +759,9 @@ int acpi_build_tables(struct acpi_ctxt *
+     memcpy(rsdp, &Rsdp, sizeof(struct acpi_20_rsdp));
+     rsdp->rsdt_address = ctxt->mem_ops.v2p(ctxt, rsdt);
+     rsdp->xsdt_address = ctxt->mem_ops.v2p(ctxt, xsdt);
++    if (needs_id_fixup) {
++        memcpy(rsdp->oem_id, slic_header->oem_id, 6);
++    }
+     set_checksum(rsdp,
+                  offsetof(struct acpi_10_rsdp, checksum),
+                  sizeof(struct acpi_10_rsdp));

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -263,6 +263,7 @@ Patch1115: patch-stubdom-linux-cmdline.patch
 Patch1116: patch-xenstore-client-raw.patch
 
 Patch1200: patch-fix-errors-on-ambiguous-python-shebang.patch
+Patch1201: patch-xen-acpi-slic-support.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: transfig libidn-devel zlib-devel texi2html SDL-devel curl-devel


### PR DESCRIPTION
This patch from OpenXT to update OEM and OEM ID signatures if SLIC table was defined. It is necessary to activate OEM media installed Windows. 