### PR TITLE
Currently disable building EFI for CentOS 7

### DIFF
--- a/xen.spec.in
+++ b/xen.spec.in
@@ -25,6 +25,9 @@
 %ifnarch x86_64
 %define build_efi 0
 %endif
+%if 0%{?rhel} == 7
+%define build_efi 0
+%endif
 %define with_python2 1
 %define with_python3 1
 


### PR DESCRIPTION
mingw64-binutils is currently removed from EPEL due to
several CVE issues (see https://bugzilla.redhat.com/show_bug.cgi?id=1807975
and https://pagure.io/fesco/issue/2333).