### PR TITLE
Resolve errors involving detaching multiple block devices

### DIFF
--- a/debian-vm/debian/rules
+++ b/debian-vm/debian/rules
@@ -30,7 +30,7 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	dh_clean --keep
-	make dist-tools
+	make debug_symbols=y dist-tools
 
 override_dh_auto_install:
 	make DESTDIR=$(DESTDIR) install-tools

--- a/patch-0001-libxl-devd-fix-a-race-with-concurrent-device-additio.patch
+++ b/patch-0001-libxl-devd-fix-a-race-with-concurrent-device-additio.patch
@@ -1,0 +1,169 @@
+From 7f04e79880a9eefcc542a91886c5a7d38001c775 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Tue, 16 May 2017 08:59:23 +0100
+Subject: [PATCH] libxl/devd: fix a race with concurrent device
+ addition/removal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Current code can free the libxl__device inside of the libxl__ddomain_device
+before the addition has finished if a removal happens while an addition is
+still in process:
+
+  backend_watch_callback
+            |
+            v
+       add_device
+            |                 backend_watch_callback
+    (async operation)                   |
+            |                           v
+            |                     remove_device
+            |                           |
+            |                           V
+            |                    device_complete
+            |                 (free libxl__device)
+            v
+     device_complete
+  (deref libxl__device)
+
+Fix this by creating a temporary copy of the libxl__device, that's tracked by
+the GC of the nested async operation. This ensures that the libxl__device used
+by the async operations cannot be freed while being used.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reported-by: Ian Jackson <ian.jackson@eu.citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Acked-by: Ian Jackson <ian.jackson@eu.citrix.com>
+Release-acked-by: Julien Grall <julien.grall@arm.com>
+Backported-by: M. Vefa Bicakci <m.v.b@runbox.com>
+(cherry picked from commit fd519a51192b97168ab1a9ca3405d75d89341ee2)
+---
+ tools/libxl/libxl.c          | 32 +++++++++++++++++++-------------
+ tools/libxl/libxl_internal.h |  4 ++++
+ 2 files changed, 23 insertions(+), 13 deletions(-)
+
+diff --git a/tools/libxl/libxl.c b/tools/libxl/libxl.c
+index acf714e1f918..dcd58c703f84 100644
+--- a/tools/libxl/libxl.c
++++ b/tools/libxl/libxl.c
+@@ -3721,9 +3721,6 @@ static void device_complete(libxl__egc *egc, libxl__ao_device *aodev)
+                libxl__device_action_to_string(aodev->action),
+                aodev->rc ? "failed" : "succeed");
+ 
+-    if (aodev->action == LIBXL__DEVICE_ACTION_REMOVE)
+-        free(aodev->dev);
+-
+     libxl__nested_ao_free(aodev->ao);
+ }
+ 
+@@ -3763,7 +3760,12 @@ static int add_device(libxl__egc *egc, libxl__ao *ao,
+ 
+         GCNEW(aodev);
+         libxl__prepare_ao_device(ao, aodev);
+-        aodev->dev = dev;
++        /*
++         * Clone the libxl__device to avoid races if remove_device is called
++         * before the device addition has finished.
++         */
++        GCNEW(aodev->dev);
++        *aodev->dev = *dev;
+         aodev->action = LIBXL__DEVICE_ACTION_ADD;
+         aodev->callback = device_complete;
+         libxl__wait_device_connection(egc, aodev);
+@@ -3806,7 +3808,12 @@ static int remove_device(libxl__egc *egc, libxl__ao *ao,
+ 
+         GCNEW(aodev);
+         libxl__prepare_ao_device(ao, aodev);
+-        aodev->dev = dev;
++        /*
++         * Clone the libxl__device to avoid races if there's a add_device
++         * running in parallel.
++         */
++        GCNEW(aodev->dev);
++        *aodev->dev = *dev;
+         aodev->action = LIBXL__DEVICE_ACTION_REMOVE;
+         aodev->callback = device_complete;
+         libxl__initiate_device_generic_remove(egc, aodev);
+@@ -3818,7 +3825,6 @@ static int remove_device(libxl__egc *egc, libxl__ao *ao,
+                 goto out;
+         }
+         libxl__device_destroy(gc, dev);
+-        free(dev);
+         /* Fall through to return > 0, no ao has been dispatched */
+     default:
+         rc = 1;
+@@ -3839,7 +3845,7 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+     char *p, *path;
+     const char *sstate, *sonline;
+     int state, online, rc, num_devs;
+-    libxl__device *dev = NULL;
++    libxl__device *dev;
+     libxl__ddomain_device *ddev = NULL;
+     libxl__ddomain_guest *dguest = NULL;
+     bool free_ao = false;
+@@ -3867,7 +3873,7 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+         goto skip;
+     online = atoi(sonline);
+ 
+-    dev = libxl__zalloc(NOGC, sizeof(*dev));
++    GCNEW(dev);
+     rc = libxl__parse_backend_path(gc, path, dev);
+     if (rc)
+         goto skip;
+@@ -3902,7 +3908,8 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+          * to the list of active devices for a given guest.
+          */
+         ddev = libxl__zalloc(NOGC, sizeof(*ddev));
+-        ddev->dev = dev;
++        ddev->dev = libxl__zalloc(NOGC, sizeof(*ddev->dev));
++        *ddev->dev = *dev;
+         LIBXL_SLIST_INSERT_HEAD(&dguest->devices, ddev, next);
+         LOG(DEBUG, "added device %s to the list of active devices", path);
+         rc = add_device(egc, nested_ao, dguest, ddev);
+@@ -3912,9 +3919,6 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+         /*
+          * Removal of an active device, remove it from the list and
+          * free it's data structures if they are no longer needed.
+-         *
+-         * The free of the associated libxl__device is left to the
+-         * helper remove_device function.
+          */
+         LIBXL_SLIST_REMOVE(&dguest->devices, ddev, libxl__ddomain_device,
+                            next);
+@@ -3923,6 +3927,7 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+         if (rc > 0)
+             free_ao = true;
+ 
++        free(ddev->dev);
+         free(ddev);
+         /* If this was the last device in the domain, remove it from the list */
+         num_devs = dguest->num_vifs + dguest->num_vbds + dguest->num_qdisks;
+@@ -3945,7 +3950,8 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+ 
+ skip:
+     libxl__nested_ao_free(nested_ao);
+-    free(dev);
++    if (ddev)
++        free(ddev->dev);
+     free(ddev);
+     free(dguest);
+     return;
+diff --git a/tools/libxl/libxl_internal.h b/tools/libxl/libxl_internal.h
+index c32a40576a9d..dd23f369f52e 100644
+--- a/tools/libxl/libxl_internal.h
++++ b/tools/libxl/libxl_internal.h
+@@ -490,6 +490,10 @@ struct libxl__ctx {
+     libxl_version_info version_info;
+ };
+ 
++/*
++ * libxl__device is a transparent structure that doesn't contain private fields
++ * or external memory references, and as such can be copied by assignment.
++ */
+ typedef struct {
+     uint32_t backend_devid;
+     uint32_t backend_domid;
+-- 
+2.21.3
+

--- a/patch-0002-libxl-devd-correctly-manipulate-the-dguest-list.patch
+++ b/patch-0002-libxl-devd-correctly-manipulate-the-dguest-list.patch
@@ -1,0 +1,114 @@
+From ae8c3889f987e19be5cec1ecdee80329286c1351 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Tue, 16 May 2017 08:59:24 +0100
+Subject: [PATCH] libxl/devd: correctly manipulate the dguest list
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Current code in backend_watch_callback has two issues when manipulating the
+dguest list:
+
+1. backend_watch_callback forgets to remove a libxl__ddomain_guest from the
+list of tracked domains when the related data is freed, causing dereferences
+later on when the list is traversed. Make sure that a domain is always removed
+from the list when freed.
+
+2. A spurious device state change can cause a dguest to be freed, with active
+devices and without being removed from the list. Fix this by always checking if
+a dguest has active devices before freeing and removing it.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reported-by: Reinis Martinsons <admin@frp.lv>
+Suggested-by: Ian Jackson <ian.jackson@eu.citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Acked-by: Ian Jackson <ian.jackson@eu.citrix.com>
+Release-acked-by: Julien Grall <julien.grall@arm.com>
+Backported-by: M. Vefa Bicakci <m.v.b@runbox.com>
+(cherry picked from commit 536ec5f13c066f10b5e8851392e622cc99f969f7)
+---
+ tools/libxl/libxl.c | 40 ++++++++++++++++++++++++++--------------
+ 1 file changed, 26 insertions(+), 14 deletions(-)
+
+diff --git a/tools/libxl/libxl.c b/tools/libxl/libxl.c
+index dcd58c703f84..4a6c9c8ff241 100644
+--- a/tools/libxl/libxl.c
++++ b/tools/libxl/libxl.c
+@@ -3735,6 +3735,25 @@ static void qdisk_spawn_outcome(libxl__egc *egc, libxl__dm_spawn_state *dmss,
+     libxl__nested_ao_free(dmss->spawn.ao);
+ }
+ 
++static void check_and_maybe_remove_guest(libxl__gc *gc,
++                                         libxl__ddomain *ddomain,
++                                         libxl__ddomain_guest *dguest)
++{
++    assert(ddomain);
++
++    if (dguest != NULL &&
++        dguest->num_vifs + dguest->num_vbds + dguest->num_qdisks == 0) {
++        LIBXL_SLIST_REMOVE(&ddomain->guests, dguest, libxl__ddomain_guest,
++                           next);
++        LOG(DEBUG, "Removed domain %u from the list of active guests",
++                   dguest->domid);
++        /* Clear any leftovers in libxl/<domid> */
++        libxl__xs_rm_checked(gc, XBT_NULL,
++                             GCSPRINTF("libxl/%u", dguest->domid));
++        free(dguest);
++    }
++}
++
+ /*
+  * The following comment applies to both add_device and remove_device.
+  *
+@@ -3844,7 +3863,7 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+     STATE_AO_GC(nested_ao);
+     char *p, *path;
+     const char *sstate, *sonline;
+-    int state, online, rc, num_devs;
++    int state, online, rc;
+     libxl__device *dev;
+     libxl__ddomain_device *ddev = NULL;
+     libxl__ddomain_guest *dguest = NULL;
+@@ -3919,6 +3938,10 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+         /*
+          * Removal of an active device, remove it from the list and
+          * free it's data structures if they are no longer needed.
++         *
++         * NB: the freeing is safe because all the async ops launched from
++         * backend_watch_callback make a copy of the data they use, so
++         * there's no risk of dereferencing.
+          */
+         LIBXL_SLIST_REMOVE(&dguest->devices, ddev, libxl__ddomain_device,
+                            next);
+@@ -3929,18 +3952,7 @@ static void backend_watch_callback(libxl__egc *egc, libxl__ev_xswatch *watch,
+ 
+         free(ddev->dev);
+         free(ddev);
+-        /* If this was the last device in the domain, remove it from the list */
+-        num_devs = dguest->num_vifs + dguest->num_vbds + dguest->num_qdisks;
+-        if (num_devs == 0) {
+-            LIBXL_SLIST_REMOVE(&ddomain->guests, dguest, libxl__ddomain_guest,
+-                               next);
+-            LOG(DEBUG, "removed domain %u from the list of active guests",
+-                       dguest->domid);
+-            /* Clear any leftovers in libxl/<domid> */
+-            libxl__xs_rm_checked(gc, XBT_NULL,
+-                                 GCSPRINTF("libxl/%u", dguest->domid));
+-            free(dguest);
+-        }
++        check_and_maybe_remove_guest(gc, ddomain, dguest);
+     }
+ 
+     if (free_ao)
+@@ -3953,7 +3965,7 @@ skip:
+     if (ddev)
+         free(ddev->dev);
+     free(ddev);
+-    free(dguest);
++    check_and_maybe_remove_guest(gc, ddomain, dguest);
+     return;
+ }
+ 
+-- 
+2.21.3
+

--- a/series-debian-vm.conf
+++ b/series-debian-vm.conf
@@ -12,6 +12,8 @@ patch-0001-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
 # backports
 patch-0001-libxl-add-more-cpuid-flags-handling.patch
 patch-libxc-panic-when-trying-to-create-a-PVH-guest-withou.patch
+patch-0001-libxl-devd-fix-a-race-with-concurrent-device-additio.patch
+patch-0002-libxl-devd-correctly-manipulate-the-dguest-list.patch
 
 # PVH backports
 patch-88e43f9a-acpi-make-pmtimer-optional-in-FADT.patch

--- a/series-vm.conf
+++ b/series-vm.conf
@@ -7,3 +7,5 @@ patch-libvchan-Fix-cleanup-when-xc_gntshr_open-failed.patch
 patch-0101-libvchan-create-xenstore-entries-in-one-transaction.patch
 patch-0001-tools-include-sys-sysmacros.h-on-Linux.patch
 patch-0001-tools-libxc-fix-strncpy-size.patch
+patch-0001-libxl-devd-fix-a-race-with-concurrent-device-additio.patch
+patch-0002-libxl-devd-correctly-manipulate-the-dguest-list.patch

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -100,6 +100,8 @@ Patch304: patch-448c03b3-tools-xenstore-try-to-get-minimum-thread-stack-size-.pa
 Patch305: patch-c9bd8a73-tools-xenstore-add-libdl-dependency-to-libxenstore.patch
 Patch306: patch-1a373194-tools-xenstore-fix-linking-libxenstore-with-ldl.patch
 Patch307: patch-xen-AMD-IOMMU-Support-IOAPIC-IDs-larger-than-128.patch
+Patch308: patch-0001-libxl-devd-fix-a-race-with-concurrent-device-additio.patch
+Patch309: patch-0002-libxl-devd-correctly-manipulate-the-dguest-list.patch
 
 
 # PVH backports

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -606,7 +606,7 @@ make %{?_smp_mflags} %{?efi_flags} prefix=/usr dist-xen
     --disable-vtpmmgr-stubdom \
     --with-extra-qemuu-configure-args="--disable-spice" \
     --disable-blktap2
-make %{?_smp_mflags} %{?ocaml_flags} prefix=/usr dist-tools
+make %{?_smp_mflags} %{?ocaml_flags} prefix=/usr debug_symbols=y dist-tools
 make                 prefix=/usr dist-docs
 unset CFLAGS
 make %{?ocaml_flags} dist-stubdom


### PR DESCRIPTION
Hello,

The topmost commit in this pull request resolves [QubesOS issue 4784](https://github.com/QubesOS/qubes-issues/issues/4784). I have verified this with a Fedora 30-based sys-usb VM on Qubes OS 4.0 only, but the commits also modify the patch series files for Debian buster (verified to compile) and ArchLinux (not verified at all).

For the record, the backported commits should already be present in the upstream version of Xen 4.13, so this pull request is specific to the xen-4.8 branch of the vmm-xen repository.

The debugging symbol enablement commit, while not directly relevant, is included in this pull request to make future debugging exercises more efficient.

Thanks!