### PR TITLE
Park unused CPU threads after suspend-to-RAM

### DIFF
--- a/patch-0001-xen-sched-call-cpu_disable_scheduler-via-cpu-notifie.patch
+++ b/patch-0001-xen-sched-call-cpu_disable_scheduler-via-cpu-notifie.patch
@@ -1,0 +1,125 @@
+From 07ce5bd2e892dfd2d6931d67caac714cf0c23e77 Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Tue, 2 Apr 2019 18:19:05 +0200
+Subject: [PATCH 1/9] xen/sched: call cpu_disable_scheduler() via cpu notifier
+
+cpu_disable_scheduler() is being called from __cpu_disable() today.
+There is no need to execute it on the cpu just being disabled, so use
+the CPU_DEAD case of the cpu notifier chain. Moving the call out of
+stop_machine() context is fine, as we just need to hold the domain RCU
+lock and need the scheduler percpu data to be still allocated.
+
+Add another hook for CPU_DOWN_PREPARE to bail out early in case
+cpu_disable_scheduler() would fail. This will avoid crashes in rare
+cases for cpu hotplug or suspend.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Acked-by: Julien Grall <julien.grall@arm.com>
+Acked-by: Andrew Cooper <andrew.cooper3@citrix.com>
+(cherry picked from commit 9b28696502d400832c012c3b3fecfebee6c75648)
+---
+ xen/arch/arm/smpboot.c |  2 --
+ xen/arch/x86/smpboot.c |  3 ---
+ xen/common/schedule.c  | 36 +++++++++++++++++++++++++++++-------
+ 3 files changed, 29 insertions(+), 12 deletions(-)
+
+diff --git a/xen/arch/arm/smpboot.c b/xen/arch/arm/smpboot.c
+index 32e87221c096..92980bda1f27 100644
+--- a/xen/arch/arm/smpboot.c
++++ b/xen/arch/arm/smpboot.c
+@@ -341,8 +341,6 @@ void __cpu_disable(void)
+     /* It's now safe to remove this processor from the online map */
+     cpumask_clear_cpu(cpu, &cpu_online_map);
+ 
+-    if ( cpu_disable_scheduler(cpu) )
+-        BUG();
+     smp_mb();
+ 
+     /* Return to caller; eventually the IPI mechanism will unwind and the 
+diff --git a/xen/arch/x86/smpboot.c b/xen/arch/x86/smpboot.c
+index ef7858fdeebc..afac724d1d33 100644
+--- a/xen/arch/x86/smpboot.c
++++ b/xen/arch/x86/smpboot.c
+@@ -1211,9 +1211,6 @@ void __cpu_disable(void)
+     cpumask_clear_cpu(cpu, &cpu_online_map);
+     fixup_irqs(&cpu_online_map, 1);
+     fixup_eoi();
+-
+-    if ( cpu_disable_scheduler(cpu) )
+-        BUG();
+ }
+ 
+ void __cpu_die(unsigned int cpu)
+diff --git a/xen/common/schedule.c b/xen/common/schedule.c
+index 6069b3278cc2..e92faa40959b 100644
+--- a/xen/common/schedule.c
++++ b/xen/common/schedule.c
+@@ -745,8 +745,9 @@ void restore_vcpu_affinity(struct domain *d)
+ }
+ 
+ /*
+- * This function is used by cpu_hotplug code from stop_machine context
++ * This function is used by cpu_hotplug code via cpu notifier chain
+  * and from cpupools to switch schedulers on a cpu.
++ * Caller must get domlist_read_lock.
+  */
+ int cpu_disable_scheduler(unsigned int cpu)
+ {
+@@ -761,12 +762,6 @@ int cpu_disable_scheduler(unsigned int cpu)
+     if ( c == NULL )
+         return ret;
+ 
+-    /*
+-     * We'd need the domain RCU lock, but:
+-     *  - when we are called from cpupool code, it's acquired there already;
+-     *  - when we are called for CPU teardown, we're in stop-machine context,
+-     *    so that's not be a problem.
+-     */
+     for_each_domain_in_cpupool ( d, c )
+     {
+         for_each_vcpu ( d, v )
+@@ -865,6 +860,24 @@ int cpu_disable_scheduler(unsigned int cpu)
+     return ret;
+ }
+ 
++static int cpu_disable_scheduler_check(unsigned int cpu)
++{
++    struct domain *d;
++    struct vcpu *v;
++    struct cpupool *c;
++
++    c = per_cpu(cpupool, cpu);
++    if ( c == NULL )
++        return 0;
++
++    for_each_domain_in_cpupool ( d, c )
++        for_each_vcpu ( d, v )
++            if ( v->affinity_broken )
++                return -EADDRINUSE;
++
++    return 0;
++}
++
+ static int vcpu_set_affinity(
+     struct vcpu *v, const cpumask_t *affinity, cpumask_t *which)
+ {
+@@ -1676,7 +1689,16 @@ static int cpu_schedule_callback(
+     case CPU_UP_PREPARE:
+         rc = cpu_schedule_up(cpu);
+         break;
++    case CPU_DOWN_PREPARE:
++        rcu_read_lock(&domlist_read_lock);
++        rc = cpu_disable_scheduler_check(cpu);
++        rcu_read_unlock(&domlist_read_lock);
++        break;
+     case CPU_DEAD:
++        rcu_read_lock(&domlist_read_lock);
++        rc = cpu_disable_scheduler(cpu);
++        BUG_ON(rc);
++        rcu_read_unlock(&domlist_read_lock);
+         SCHED_OP(sched, deinit_pdata, sd->sched_priv, cpu);
+         /* Fallthrough */
+     case CPU_UP_CANCELED:
+-- 
+2.26.2
+

--- a/patch-0002-xen-add-helper-for-calling-notifier_call_chain-to-co.patch
+++ b/patch-0002-xen-add-helper-for-calling-notifier_call_chain-to-co.patch
@@ -1,0 +1,155 @@
+From 3816d82fba6c67b599c970dfe7bc8e024b7e2042 Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Tue, 2 Apr 2019 07:34:53 +0200
+Subject: [PATCH 2/9] xen: add helper for calling notifier_call_chain() to
+ common/cpu.c
+
+Add a helper cpu_notifier_call_chain() to call notifier_call_chain()
+for a cpu with a specified action, returning an errno value.
+
+This avoids coding the same pattern multiple times.
+
+While at it avoid side effects from using BUG_ON() by not using
+cpu_online(cpu) as a parameter.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Reviewed-by: Dario Faggioli <dfaggioli@suse.com>
+Acked-by: Jan Beulich <jbeulich@suse.com>
+(cherry picked from commit 8d88eacb3b390984e2c483d75d8f40b3ec4be67c)
+---
+ xen/common/cpu.c | 56 ++++++++++++++++++++++--------------------------
+ 1 file changed, 26 insertions(+), 30 deletions(-)
+
+diff --git a/xen/common/cpu.c b/xen/common/cpu.c
+index ca415babf8d2..ccf62b5e013e 100644
+--- a/xen/common/cpu.c
++++ b/xen/common/cpu.c
+@@ -68,11 +68,21 @@ void __init register_cpu_notifier(struct notifier_block *nb)
+     spin_unlock(&cpu_add_remove_lock);
+ }
+ 
++static int cpu_notifier_call_chain(unsigned int cpu, unsigned long action,
++                                   struct notifier_block **nb, bool nofail)
++{
++    void *hcpu = (void *)(long)cpu;
++    int notifier_rc = notifier_call_chain(&cpu_chain, action, hcpu, nb);
++    int ret = (notifier_rc == NOTIFY_DONE) ? 0 : notifier_to_errno(notifier_rc);
++
++    BUG_ON(ret && nofail);
++
++    return ret;
++}
++
+ static void _take_cpu_down(void *unused)
+ {
+-    void *hcpu = (void *)(long)smp_processor_id();
+-    int notifier_rc = notifier_call_chain(&cpu_chain, CPU_DYING, hcpu, NULL);
+-    BUG_ON(notifier_rc != NOTIFY_DONE);
++    cpu_notifier_call_chain(smp_processor_id(), CPU_DYING, NULL, true);
+     __cpu_disable();
+ }
+ 
+@@ -84,8 +94,7 @@ static int take_cpu_down(void *arg)
+ 
+ int cpu_down(unsigned int cpu)
+ {
+-    int err, notifier_rc;
+-    void *hcpu = (void *)(long)cpu;
++    int err;
+     struct notifier_block *nb = NULL;
+ 
+     if ( !cpu_hotplug_begin() )
+@@ -97,12 +106,9 @@ int cpu_down(unsigned int cpu)
+         return -EINVAL;
+     }
+ 
+-    notifier_rc = notifier_call_chain(&cpu_chain, CPU_DOWN_PREPARE, hcpu, &nb);
+-    if ( notifier_rc != NOTIFY_DONE )
+-    {
+-        err = notifier_to_errno(notifier_rc);
++    err = cpu_notifier_call_chain(cpu, CPU_DOWN_PREPARE, &nb, false);
++    if ( err )
+         goto fail;
+-    }
+ 
+     if ( unlikely(system_state < SYS_STATE_active) )
+         on_selected_cpus(cpumask_of(cpu), _take_cpu_down, NULL, true);
+@@ -110,26 +116,24 @@ int cpu_down(unsigned int cpu)
+         goto fail;
+ 
+     __cpu_die(cpu);
+-    BUG_ON(cpu_online(cpu));
++    err = cpu_online(cpu);
++    BUG_ON(err);
+ 
+-    notifier_rc = notifier_call_chain(&cpu_chain, CPU_DEAD, hcpu, NULL);
+-    BUG_ON(notifier_rc != NOTIFY_DONE);
++    cpu_notifier_call_chain(cpu, CPU_DEAD, NULL, true);
+ 
+     send_global_virq(VIRQ_PCPU_STATE);
+     cpu_hotplug_done();
+     return 0;
+ 
+  fail:
+-    notifier_rc = notifier_call_chain(&cpu_chain, CPU_DOWN_FAILED, hcpu, &nb);
+-    BUG_ON(notifier_rc != NOTIFY_DONE);
++    cpu_notifier_call_chain(cpu, CPU_DOWN_FAILED, &nb, true);
+     cpu_hotplug_done();
+     return err;
+ }
+ 
+ int cpu_up(unsigned int cpu)
+ {
+-    int notifier_rc, err = 0;
+-    void *hcpu = (void *)(long)cpu;
++    int err;
+     struct notifier_block *nb = NULL;
+ 
+     if ( !cpu_hotplug_begin() )
+@@ -141,19 +145,15 @@ int cpu_up(unsigned int cpu)
+         return -EINVAL;
+     }
+ 
+-    notifier_rc = notifier_call_chain(&cpu_chain, CPU_UP_PREPARE, hcpu, &nb);
+-    if ( notifier_rc != NOTIFY_DONE )
+-    {
+-        err = notifier_to_errno(notifier_rc);
++    err = cpu_notifier_call_chain(cpu, CPU_UP_PREPARE, &nb, false);
++    if ( err )
+         goto fail;
+-    }
+ 
+     err = __cpu_up(cpu);
+     if ( err < 0 )
+         goto fail;
+ 
+-    notifier_rc = notifier_call_chain(&cpu_chain, CPU_ONLINE, hcpu, NULL);
+-    BUG_ON(notifier_rc != NOTIFY_DONE);
++    cpu_notifier_call_chain(cpu, CPU_ONLINE, NULL, true);
+ 
+     send_global_virq(VIRQ_PCPU_STATE);
+ 
+@@ -161,18 +161,14 @@ int cpu_up(unsigned int cpu)
+     return 0;
+ 
+  fail:
+-    notifier_rc = notifier_call_chain(&cpu_chain, CPU_UP_CANCELED, hcpu, &nb);
+-    BUG_ON(notifier_rc != NOTIFY_DONE);
++    cpu_notifier_call_chain(cpu, CPU_UP_CANCELED, &nb, true);
+     cpu_hotplug_done();
+     return err;
+ }
+ 
+ void notify_cpu_starting(unsigned int cpu)
+ {
+-    void *hcpu = (void *)(long)cpu;
+-    int notifier_rc = notifier_call_chain(
+-        &cpu_chain, CPU_STARTING, hcpu, NULL);
+-    BUG_ON(notifier_rc != NOTIFY_DONE);
++    cpu_notifier_call_chain(cpu, CPU_STARTING, NULL, true);
+ }
+ 
+ static cpumask_t frozen_cpus;
+-- 
+2.26.2
+

--- a/patch-0003-xen-add-new-cpu-notifier-action-CPU_RESUME_FAILED.patch
+++ b/patch-0003-xen-add-new-cpu-notifier-action-CPU_RESUME_FAILED.patch
@@ -1,0 +1,95 @@
+From b14779c4ada96c52d0c1964fcf6ef20416012478 Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Tue, 2 Apr 2019 07:34:54 +0200
+Subject: [PATCH 3/9] xen: add new cpu notifier action CPU_RESUME_FAILED
+
+Add a new cpu notifier action CPU_RESUME_FAILED which is called for all
+cpus which failed to come up at resume. The calls will be done after
+all other cpus are already up in order to know which resources are
+available then.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Reviewed-by: Dario Faggioli <dfaggioli@suse.com>
+Reviewed-by: George Dunlap <george.dunlap@citrix.com>
+(cherry picked from commit 51c79e943fb3f9a746181f8b8415cf2baa5d26bd)
+---
+ xen/common/cpu.c      |  5 +++++
+ xen/include/xen/cpu.h | 29 ++++++++++++++++++-----------
+ 2 files changed, 23 insertions(+), 11 deletions(-)
+
+diff --git a/xen/common/cpu.c b/xen/common/cpu.c
+index ccf62b5e013e..8dca74cbb0bd 100644
+--- a/xen/common/cpu.c
++++ b/xen/common/cpu.c
+@@ -215,7 +215,12 @@ void enable_nonboot_cpus(void)
+             printk("Error bringing CPU%d up: %d\n", cpu, error);
+             BUG_ON(error == -EBUSY);
+         }
++        else
++            __cpumask_clear_cpu(cpu, &frozen_cpus);
+     }
+ 
++    for_each_cpu ( cpu, &frozen_cpus )
++        cpu_notifier_call_chain(cpu, CPU_RESUME_FAILED, NULL, true);
++
+     cpumask_clear(&frozen_cpus);
+ }
+diff --git a/xen/include/xen/cpu.h b/xen/include/xen/cpu.h
+index 2fe3ec05d851..4638c509e271 100644
+--- a/xen/include/xen/cpu.h
++++ b/xen/include/xen/cpu.h
+@@ -22,33 +22,40 @@ void register_cpu_notifier(struct notifier_block *nb);
+  *  CPU_UP_PREPARE -> CPU_STARTING -> CPU_ONLINE -- successful CPU up
+  *  CPU_DOWN_PREPARE -> CPU_DOWN_FAILED          -- failed CPU down
+  *  CPU_DOWN_PREPARE -> CPU_DYING -> CPU_DEAD    -- successful CPU down
+- * 
++ * in the resume case we have additionally:
++ *  CPU_UP_PREPARE -> CPU_UP_CANCELLED -> CPU_RESUME_FAILED -- CPU not resumed
++ *  with the CPU_RESUME_FAILED handler called only after all CPUs have been
++ *  tried to put online again in order to know which CPUs did restart
++ *  successfully.
++ *
+  * Hence note that only CPU_*_PREPARE handlers are allowed to fail. Also note
+  * that once CPU_DYING is delivered, an offline action can no longer fail.
+- * 
++ *
+  * Notifiers are called highest-priority-first when:
+  *  (a) A CPU is coming up; or (b) CPU_DOWN_FAILED
+  * Notifiers are called lowest-priority-first when:
+  *  (a) A CPU is going down; or (b) CPU_UP_CANCELED
+  */
+ /* CPU_UP_PREPARE: Preparing to bring CPU online. */
+-#define CPU_UP_PREPARE   (0x0001 | NOTIFY_FORWARD)
++#define CPU_UP_PREPARE    (0x0001 | NOTIFY_FORWARD)
+ /* CPU_UP_CANCELED: CPU is no longer being brought online. */
+-#define CPU_UP_CANCELED  (0x0002 | NOTIFY_REVERSE)
++#define CPU_UP_CANCELED   (0x0002 | NOTIFY_REVERSE)
+ /* CPU_STARTING: CPU nearly online. Runs on new CPU, irqs still disabled. */
+-#define CPU_STARTING     (0x0003 | NOTIFY_FORWARD)
++#define CPU_STARTING      (0x0003 | NOTIFY_FORWARD)
+ /* CPU_ONLINE: CPU is up. */
+-#define CPU_ONLINE       (0x0004 | NOTIFY_FORWARD)
++#define CPU_ONLINE        (0x0004 | NOTIFY_FORWARD)
+ /* CPU_DOWN_PREPARE: CPU is going down. */
+-#define CPU_DOWN_PREPARE (0x0005 | NOTIFY_REVERSE)
++#define CPU_DOWN_PREPARE  (0x0005 | NOTIFY_REVERSE)
+ /* CPU_DOWN_FAILED: CPU is no longer going down. */
+-#define CPU_DOWN_FAILED  (0x0006 | NOTIFY_FORWARD)
++#define CPU_DOWN_FAILED   (0x0006 | NOTIFY_FORWARD)
+ /* CPU_DYING: CPU is nearly dead (in stop_machine context). */
+-#define CPU_DYING        (0x0007 | NOTIFY_REVERSE)
++#define CPU_DYING         (0x0007 | NOTIFY_REVERSE)
+ /* CPU_DEAD: CPU is dead. */
+-#define CPU_DEAD         (0x0008 | NOTIFY_REVERSE)
++#define CPU_DEAD          (0x0008 | NOTIFY_REVERSE)
+ /* CPU_REMOVE: CPU was removed. */
+-#define CPU_REMOVE       (0x0009 | NOTIFY_REVERSE)
++#define CPU_REMOVE        (0x0009 | NOTIFY_REVERSE)
++/* CPU_RESUME_FAILED: CPU failed to come up in resume, all other CPUs up. */
++#define CPU_RESUME_FAILED (0x000a | NOTIFY_REVERSE)
+ 
+ /* Perform CPU hotplug. May return -EAGAIN. */
+ int cpu_down(unsigned int cpu);
+-- 
+2.26.2
+

--- a/patch-0004-xen-don-t-free-percpu-areas-during-suspend.patch
+++ b/patch-0004-xen-don-t-free-percpu-areas-during-suspend.patch
@@ -1,0 +1,46 @@
+From 60584e7ad08703fcdacf6d3f9c1e0b5065e97bd2 Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Tue, 2 Apr 2019 07:34:55 +0200
+Subject: [PATCH 4/9] xen: don't free percpu areas during suspend
+
+Instead of freeing percpu areas during suspend and allocating them
+again when resuming keep them. Only free an area in case a cpu didn't
+come up again when resuming.
+
+It should be noted that there is a potential change in behaviour as
+the percpu areas are no longer zeroed out during suspend/resume. While
+I have checked the called cpu notifier hooks to cope with that there
+might be some well hidden dependency on the previous behaviour. OTOH
+a component not registering itself for cpu down/up and expecting to
+see a zeroed percpu variable after suspend/resume is kind of broken
+already. And the opposite case, where a component is not registered
+to be called for cpu down/up and is not expecting a percpu variable
+suddenly to be zero due to suspend/resume is much more probable,
+especially as the suspend/resume functionality seems not to be tested
+that often.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Reviewed-by: Dario Faggioli <dfaggioli@suse.com>
+Acked-by: Jan Beulich <jbeulich@suse.com>
+(cherry picked from commit aca2a985a55ad9a0fcc1a9f23c8c4755598928ec)
+---
+ xen/arch/x86/percpu.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/xen/arch/x86/percpu.c b/xen/arch/x86/percpu.c
+index bd87855a9cce..d7f5440928c0 100644
+--- a/xen/arch/x86/percpu.c
++++ b/xen/arch/x86/percpu.c
+@@ -70,7 +70,8 @@ static int cpu_percpu_callback(
+         break;
+     case CPU_UP_CANCELED:
+     case CPU_DEAD:
+-        if ( !park_offline_cpus )
++    case CPU_RESUME_FAILED:
++        if ( !park_offline_cpus && system_state != SYS_STATE_suspend )
+             free_percpu_area(cpu);
+         break;
+     case CPU_REMOVE:
+-- 
+2.26.2
+

--- a/patch-0005-xen-cpupool-simplify-suspend-resume-handling.patch
+++ b/patch-0005-xen-cpupool-simplify-suspend-resume-handling.patch
@@ -1,0 +1,228 @@
+From 6d54ec93842934303db0e81d462ab8aaaca1fd3d Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Tue, 2 Apr 2019 07:34:56 +0200
+Subject: [PATCH 5/9] xen/cpupool: simplify suspend/resume handling
+
+Instead of removing cpus temporarily from cpupools during
+suspend/resume only remove cpus finally which didn't come up when
+resuming.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Reviewed-by: George Dunlap <george.dunlap@citrix.com>
+Reviewed-by: Dario Faggioli <dfaggioli@suse.com>
+(cherry picked from commit 6870ea9d1fad6fbe27cf3ce5fe093be709ad2668)
+---
+ xen/common/cpupool.c       | 131 +++++++++++++++----------------------
+ xen/include/xen/sched-if.h |   1 -
+ 2 files changed, 52 insertions(+), 80 deletions(-)
+
+diff --git a/xen/common/cpupool.c b/xen/common/cpupool.c
+index 1e8edcbd5794..cae19fda6e11 100644
+--- a/xen/common/cpupool.c
++++ b/xen/common/cpupool.c
+@@ -47,12 +47,6 @@ static struct cpupool *alloc_cpupool_struct(void)
+         xfree(c);
+         c = NULL;
+     }
+-    else if ( !zalloc_cpumask_var(&c->cpu_suspended) )
+-    {
+-        free_cpumask_var(c->cpu_valid);
+-        xfree(c);
+-        c = NULL;
+-    }
+ 
+     return c;
+ }
+@@ -60,10 +54,7 @@ static struct cpupool *alloc_cpupool_struct(void)
+ static void free_cpupool_struct(struct cpupool *c)
+ {
+     if ( c )
+-    {
+-        free_cpumask_var(c->cpu_suspended);
+         free_cpumask_var(c->cpu_valid);
+-    }
+     xfree(c);
+ }
+ 
+@@ -477,10 +468,6 @@ void cpupool_rm_domain(struct domain *d)
+ /*
+  * Called to add a cpu to a pool. CPUs being hot-plugged are added to pool0,
+  * as they must have been in there when unplugged.
+- *
+- * If, on the other hand, we are adding CPUs because we are resuming (e.g.,
+- * after ACPI S3) we put the cpu back in the pool where it was in prior when
+- * we suspended.
+  */
+ static int cpupool_cpu_add(unsigned int cpu)
+ {
+@@ -490,42 +477,15 @@ static int cpupool_cpu_add(unsigned int cpu)
+     cpumask_clear_cpu(cpu, &cpupool_locked_cpus);
+     cpumask_set_cpu(cpu, &cpupool_free_cpus);
+ 
+-    if ( system_state == SYS_STATE_suspend || system_state == SYS_STATE_resume )
+-    {
+-        struct cpupool **c;
+-
+-        for_each_cpupool(c)
+-        {
+-            if ( cpumask_test_cpu(cpu, (*c)->cpu_suspended ) )
+-            {
+-                ret = cpupool_assign_cpu_locked(*c, cpu);
+-                if ( ret )
+-                    goto out;
+-                cpumask_clear_cpu(cpu, (*c)->cpu_suspended);
+-                break;
+-            }
+-        }
++    /*
++     * If we are not resuming, we are hot-plugging cpu, and in which case
++     * we add it to pool0, as it certainly was there when hot-unplagged
++     * (or unplugging would have failed) and that is the default behavior
++     * anyway.
++     */
++    per_cpu(cpupool, cpu) = NULL;
++    ret = cpupool_assign_cpu_locked(cpupool0, cpu);
+ 
+-        /*
+-         * Either cpu has been found as suspended in a pool, and added back
+-         * there, or it stayed free (if it did not belong to any pool when
+-         * suspending), and we don't want to do anything.
+-         */
+-        ASSERT(cpumask_test_cpu(cpu, &cpupool_free_cpus) ||
+-               cpumask_test_cpu(cpu, (*c)->cpu_valid));
+-    }
+-    else
+-    {
+-        /*
+-         * If we are not resuming, we are hot-plugging cpu, and in which case
+-         * we add it to pool0, as it certainly was there when hot-unplagged
+-         * (or unplugging would have failed) and that is the default behavior
+-         * anyway.
+-         */
+-        per_cpu(cpupool, cpu) = NULL;
+-        ret = cpupool_assign_cpu_locked(cpupool0, cpu);
+-    }
+- out:
+     spin_unlock(&cpupool_lock);
+ 
+     return ret;
+@@ -535,42 +495,14 @@ static int cpupool_cpu_add(unsigned int cpu)
+  * Called to remove a CPU from a pool. The CPU is locked, to forbid removing
+  * it from pool0. In fact, if we want to hot-unplug a CPU, it must belong to
+  * pool0, or we fail.
+- *
+- * However, if we are suspending (e.g., to ACPI S3), we mark the CPU in such
+- * a way that it can be put back in its pool when resuming.
+  */
+ static int cpupool_cpu_remove(unsigned int cpu)
+ {
+     int ret = -ENODEV;
+ 
+     spin_lock(&cpupool_lock);
+-    if ( system_state == SYS_STATE_suspend )
+-    {
+-        struct cpupool **c;
+-
+-        for_each_cpupool(c)
+-        {
+-            if ( cpumask_test_cpu(cpu, (*c)->cpu_valid ) )
+-            {
+-                cpumask_set_cpu(cpu, (*c)->cpu_suspended);
+-                cpumask_clear_cpu(cpu, (*c)->cpu_valid);
+-                break;
+-            }
+-        }
+ 
+-        /*
+-         * Either we found cpu in a pool, or it must be free (if it has been
+-         * hot-unplagged, then we must have found it in pool0). It is, of
+-         * course, fine to suspend or shutdown with CPUs not assigned to a
+-         * pool, and (in case of suspend) they will stay free when resuming.
+-         */
+-        ASSERT(cpumask_test_cpu(cpu, &cpupool_free_cpus) ||
+-               cpumask_test_cpu(cpu, (*c)->cpu_suspended));
+-        ASSERT(cpumask_test_cpu(cpu, &cpu_online_map) ||
+-               cpumask_test_cpu(cpu, cpupool0->cpu_suspended));
+-        ret = 0;
+-    }
+-    else if ( cpumask_test_cpu(cpu, cpupool0->cpu_valid) )
++    if ( cpumask_test_cpu(cpu, cpupool0->cpu_valid) )
+     {
+         /*
+          * If we are not suspending, we are hot-unplugging cpu, and that is
+@@ -587,6 +519,41 @@ static int cpupool_cpu_remove(unsigned int cpu)
+     return ret;
+ }
+ 
++/*
++ * Called during resume for all cpus which didn't come up again. The cpu must
++ * be removed from the cpupool it is assigned to. In case a cpupool will be
++ * left without cpu we move all domains of that cpupool to cpupool0.
++ */
++static void cpupool_cpu_remove_forced(unsigned int cpu)
++{
++    struct cpupool **c;
++    struct domain *d;
++
++    spin_lock(&cpupool_lock);
++
++    if ( cpumask_test_cpu(cpu, &cpupool_free_cpus) )
++        cpumask_clear_cpu(cpu, &cpupool_free_cpus);
++    else
++    {
++        for_each_cpupool(c)
++        {
++            if ( cpumask_test_cpu(cpu, (*c)->cpu_valid) )
++            {
++                cpumask_clear_cpu(cpu, (*c)->cpu_valid);
++                if ( cpumask_weight((*c)->cpu_valid) == 0 )
++                {
++                    if ( *c == cpupool0 )
++                        panic("No cpu left in cpupool0\n");
++                    for_each_domain_in_cpupool(d, *c)
++                        cpupool_move_domain_locked(d, cpupool0);
++                }
++            }
++        }
++    }
++
++    spin_unlock(&cpupool_lock);
++}
++
+ /*
+  * do cpupool related sysctl operations
+  */
+@@ -779,10 +746,16 @@ static int cpu_callback(
+     {
+     case CPU_DOWN_FAILED:
+     case CPU_ONLINE:
+-        rc = cpupool_cpu_add(cpu);
++        if ( system_state <= SYS_STATE_active )
++            rc = cpupool_cpu_add(cpu);
+         break;
+     case CPU_DOWN_PREPARE:
+-        rc = cpupool_cpu_remove(cpu);
++        /* Suspend/Resume don't change assignments of cpus to cpupools. */
++        if ( system_state <= SYS_STATE_active )
++            rc = cpupool_cpu_remove(cpu);
++        break;
++    case CPU_RESUME_FAILED:
++        cpupool_cpu_remove_forced(cpu);
+         break;
+     default:
+         break;
+diff --git a/xen/include/xen/sched-if.h b/xen/include/xen/sched-if.h
+index bc0e794b0f86..4d7a19295684 100644
+--- a/xen/include/xen/sched-if.h
++++ b/xen/include/xen/sched-if.h
+@@ -181,7 +181,6 @@ struct cpupool
+ {
+     int              cpupool_id;
+     cpumask_var_t    cpu_valid;      /* all cpus assigned to pool */
+-    cpumask_var_t    cpu_suspended;  /* cpus in S3 that should be in this pool */
+     struct cpupool   *next;
+     unsigned int     n_dom;
+     struct scheduler *sched;
+-- 
+2.26.2
+

--- a/patch-0006-x86-ACPI-re-park-previously-parked-CPUs-upon-resume-.patch
+++ b/patch-0006-x86-ACPI-re-park-previously-parked-CPUs-upon-resume-.patch
@@ -1,0 +1,61 @@
+From c2d8f6a77fe7da9d12613729693301265581521b Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 30 Aug 2019 10:24:13 +0200
+Subject: [PATCH 6/9] x86/ACPI: re-park previously parked CPUs upon resume from
+ S3
+
+Aiui when resuming from S3, CPUs come back out of RESET/INIT. Therefore
+they need to undergo the same procedure as was added elsewhere by
+commits d8f974f1a6 ("x86: command line option to avoid use of secondary
+hyper-threads") and 8797d20a6e ("x86: possibly bring up all CPUs even
+if not all are supposed to be used").
+
+Just like done at boot time, avoid (at least pointlessly) using
+stop-machine logic.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Andrew Cooper <andrew.cooper3@citrix.com>
+(cherry picked from commit eb912011076e76f6c5e4013616a61ba670e7fc15)
+---
+ xen/common/cpu.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/xen/common/cpu.c b/xen/common/cpu.c
+index 8dca74cbb0bd..ecd63aa9a92c 100644
+--- a/xen/common/cpu.c
++++ b/xen/common/cpu.c
+@@ -110,7 +110,7 @@ int cpu_down(unsigned int cpu)
+     if ( err )
+         goto fail;
+ 
+-    if ( unlikely(system_state < SYS_STATE_active) )
++    if ( system_state < SYS_STATE_active || system_state == SYS_STATE_resume )
+         on_selected_cpus(cpumask_of(cpu), _take_cpu_down, NULL, true);
+     else if ( (err = stop_machine_run(take_cpu_down, NULL, cpu)) < 0 )
+         goto fail;
+@@ -208,15 +208,19 @@ void enable_nonboot_cpus(void)
+ 
+     printk("Enabling non-boot CPUs  ...\n");
+ 
+-    for_each_cpu ( cpu, &frozen_cpus )
++    for_each_present_cpu ( cpu )
+     {
++        if ( park_offline_cpus ? cpu == smp_processor_id()
++                               : !cpumask_test_cpu(cpu, &frozen_cpus) )
++            continue;
+         if ( (error = cpu_up(cpu)) )
+         {
+             printk("Error bringing CPU%d up: %d\n", cpu, error);
+             BUG_ON(error == -EBUSY);
+         }
+-        else
+-            __cpumask_clear_cpu(cpu, &frozen_cpus);
++        else if ( !__cpumask_test_and_clear_cpu(cpu, &frozen_cpus) &&
++                  (error = cpu_down(cpu)) )
++            printk("Error re-offlining CPU%d: %d\n", cpu, error);
+     }
+ 
+     for_each_cpu ( cpu, &frozen_cpus )
+-- 
+2.26.2
+

--- a/patch-0007-sched-populate-cpupool0-only-after-all-cpus-are-up.patch
+++ b/patch-0007-sched-populate-cpupool0-only-after-all-cpus-are-up.patch
@@ -1,0 +1,61 @@
+From b3541dd6cdb0ef9f31b8860e59bf0ee524a2c6e6 Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Tue, 17 Sep 2019 16:09:50 +0200
+Subject: [PATCH 7/9] sched: populate cpupool0 only after all cpus are up
+
+Simplify cpupool initialization by populating cpupool0 with cpus only
+after all cpus are up. This avoids having to call the cpu notifier
+directly for cpu 0.
+
+With that in place there is no need to create cpupool0 earlier, so
+do that just before assigning the cpus. Initialize free cpus with all
+online cpus at that time in order to be able to add the cpu notifier
+late, too.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Reviewed-by: Dario Faggioli <dfaggioli@suse.com>
+(cherry picked from commit b0000b128adb07f4107c6e324d32ab025a73a6c8)
+---
+ xen/common/cpupool.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/xen/common/cpupool.c b/xen/common/cpupool.c
+index cae19fda6e11..7ab13d25ab0e 100644
+--- a/xen/common/cpupool.c
++++ b/xen/common/cpupool.c
+@@ -768,18 +768,28 @@ static struct notifier_block cpu_nfb = {
+     .notifier_call = cpu_callback
+ };
+ 
+-static int __init cpupool_presmp_init(void)
++static int __init cpupool_init(void)
+ {
++    unsigned int cpu;
+     int err;
+-    void *cpu = (void *)(long)smp_processor_id();
++
+     cpupool0 = cpupool_create(0, 0, &err);
+     BUG_ON(cpupool0 == NULL);
+     cpupool_put(cpupool0);
+-    cpu_callback(&cpu_nfb, CPU_ONLINE, cpu);
+     register_cpu_notifier(&cpu_nfb);
++
++    spin_lock(&cpupool_lock);
++
++    cpumask_copy(&cpupool_free_cpus, &cpu_online_map);
++
++    for_each_cpu ( cpu, &cpupool_free_cpus )
++        cpupool_assign_cpu_locked(cpupool0, cpu);
++
++    spin_unlock(&cpupool_lock);
++
+     return 0;
+ }
+-presmp_initcall(cpupool_presmp_init);
++__initcall(cpupool_init);
+ 
+ /*
+  * Local variables:
+-- 
+2.26.2
+

--- a/patch-0008-x86-clear-per-cpu-stub-page-information-in-cpu_smpbo.patch
+++ b/patch-0008-x86-clear-per-cpu-stub-page-information-in-cpu_smpbo.patch
@@ -1,0 +1,41 @@
+From 654c767b3f8f8e27562aee8622e633a1cd4f4a1b Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Thu, 9 Jan 2020 11:07:38 +0100
+Subject: [PATCH 8/9] x86: clear per cpu stub page information in
+ cpu_smpboot_free()
+
+cpu_smpboot_free() removes the stubs for the cpu going offline, but it
+isn't clearing the related percpu variables. This will result in
+crashes when a stub page is released due to all related cpus gone
+offline and one of those cpus going online later.
+
+Fix that by clearing stubs.addr and stubs.mfn in order to allocate a
+new stub page when needed, irrespective of whether the CPU gets parked
+or removed.
+
+Fixes: 2e6c8f182c9c50 ("x86: distinguish CPU offlining from CPU removal")
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Reviewed-by: Wei Liu <wl@xen.org>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Tested-by: Tao Xu <tao3.xu@intel.com>
+(cherry picked from commit 774901788c5614798931a1cb2e20dd8b885f97ab)
+---
+ xen/arch/x86/smpboot.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/xen/arch/x86/smpboot.c b/xen/arch/x86/smpboot.c
+index afac724d1d33..83b3bf70b706 100644
+--- a/xen/arch/x86/smpboot.c
++++ b/xen/arch/x86/smpboot.c
+@@ -946,6 +946,8 @@ static void cpu_smpboot_free(unsigned int cpu, bool remove)
+         unmap_domain_page(stub_page);
+         destroy_xen_mappings(per_cpu(stubs.addr, cpu) & PAGE_MASK,
+                              (per_cpu(stubs.addr, cpu) | ~PAGE_MASK) + 1);
++        per_cpu(stubs.addr, cpu) = 0;
++        per_cpu(stubs.mfn, cpu) = 0;
+         if ( i == STUBS_PER_PAGE )
+             free_domheap_page(mfn_to_page(mfn));
+     }
+-- 
+2.26.2
+

--- a/patch-0009-x86-S3-put-data-segment-registers-into-known-state-u.patch
+++ b/patch-0009-x86-S3-put-data-segment-registers-into-known-state-u.patch
@@ -1,0 +1,49 @@
+From 55ffc4e5acaccb6dc47e5b51a9c6db32440616b3 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 7 Aug 2020 17:31:16 +0200
+Subject: [PATCH] x86/S3: put data segment registers into known state upon
+ resume
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+wakeup_32 sets %ds and %es to BOOT_DS, while leaving %fs at what
+wakeup_start did set it to, and %gs at whatever BIOS did load into it.
+All of this may end up confusing the first load_segments() to run on
+the BSP after resume, in particular allowing a non-nul selector value
+to be left in %fs.
+
+Alongside %ss, also put all other data segment registers into the same
+state that the boot and CPU bringup paths put them in.
+
+Reported-by: M. Vefa Bicakci <m.v.b@runbox.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+master commit: 55f8c389d4348cc517946fdcb10794112458e81e
+master date: 2020-07-24 10:17:26 +0200
+(cherry picked from commit 85ce36d12b43ed15e556265c6204858d3b52d747)
+---
+ xen/arch/x86/acpi/wakeup_prot.S | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/xen/arch/x86/acpi/wakeup_prot.S b/xen/arch/x86/acpi/wakeup_prot.S
+index def86d2f4572..5f8ef8ce0c83 100644
+--- a/xen/arch/x86/acpi/wakeup_prot.S
++++ b/xen/arch/x86/acpi/wakeup_prot.S
+@@ -84,6 +84,12 @@ ENTRY(__ret_point)
+         mov     REF(saved_ss), %ss
+         LOAD_GREG(sp)
+ 
++        mov     $__HYPERVISOR_DS64, %eax
++        mov     %eax, %ds
++        mov     %eax, %es
++        mov     %eax, %fs
++        mov     %eax, %gs
++
+         /* Reload code selector */
+         pushq   $(__HYPERVISOR_CS64)
+         leaq    1f(%rip),%rax
+-- 
+2.26.2
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -112,6 +112,15 @@ Patch316: patch-0002-passthrough-don-t-migrate-pirq-when-it-is-delivered-.patch
 Patch317: patch-0003-VT-d-introduce-new-fields-in-msi_desc-to-track-bindi.patch
 Patch318: patch-0004-VT-d-some-cleanups.patch
 Patch319: patch-0005-VT-d-introduce-update_irte-to-update-irte-safely.patch
+Patch320: patch-0001-xen-sched-call-cpu_disable_scheduler-via-cpu-notifie.patch
+Patch321: patch-0002-xen-add-helper-for-calling-notifier_call_chain-to-co.patch
+Patch322: patch-0003-xen-add-new-cpu-notifier-action-CPU_RESUME_FAILED.patch
+Patch323: patch-0004-xen-don-t-free-percpu-areas-during-suspend.patch
+Patch324: patch-0005-xen-cpupool-simplify-suspend-resume-handling.patch
+Patch325: patch-0006-x86-ACPI-re-park-previously-parked-CPUs-upon-resume-.patch
+Patch326: patch-0007-sched-populate-cpupool0-only-after-all-cpus-are-up.patch
+Patch327: patch-0008-x86-clear-per-cpu-stub-page-information-in-cpu_smpbo.patch
+Patch328: patch-0009-x86-S3-put-data-segment-registers-into-known-state-u.patch
 
 # PVH backports
 Patch401: patch-88e43f9a-acpi-make-pmtimer-optional-in-FADT.patch


### PR DESCRIPTION
This pull request intends to resolve QubesOS/qubes-issues#5210 by cherry-picking 9 commits to the version of Xen 4.8 shipped by Qubes OS, so that unused CPU hyperthreads are parked during the resume from suspend-to-RAM. For information about how this pull request was verified to resolve this issue, please see the commit message.

The 9th patch is a bit special and is required to resolve intermittent segmentation faults encountered by `systemd-sleep` (after applying the first 8 patches) during the resume from suspend-to-RAM; more details about this patch can be found in the commit message as well.