### PR TITLE
deb, arch: migrate to python3 completely

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -13,7 +13,7 @@ arch=("x86_64")
 url="http://qubes-os.org/"
 license=('GPL')
 groups=()
-depends=(python2 bridge-utils python2-lxml libutil-linux lzo libsystemd yajl)
+depends=(python bridge-utils python-lxml libutil-linux lzo libsystemd yajl)
 makedepends=(wget make gcc patch git bin86 dev86 iasl yajl pkg-config openssl pixman)
 checkdepends=()
 optdepends=()
@@ -43,7 +43,6 @@ build() {
 
   export XEN_VENDORVERSION="-$pkgrel"
   export OCAML_TOOLS=n
-  export PYTHON=/usr/bin/python2
   unset LDFLAGS
 
   autoreconf
@@ -64,7 +63,6 @@ package() {
   cd xen-$pkgver
 
   export OCAML_TOOLS=n
-  export PYTHON=python2
   # Note: Archlinux removed use of directory such as /sbin /bin /usr/sbin (https://mailman.archlinux.org/pipermail/arch-dev-public/2012-March/022625.html)
   make DESTDIR=$pkgdir LIBDIR=/usr/lib/ SBINDIR=/usr/bin prefix=/usr install-tools
 

--- a/debian-vm/debian/control
+++ b/debian-vm/debian/control
@@ -10,7 +10,6 @@ Build-Depends:
    dpkg-dev (>= 1.16.0~),
    rdfind,
    lsb-release,
-   python-dev,
    dh-python,
    bcc [i386 amd64],
    bison,
@@ -62,7 +61,7 @@ Package: xen-utils-common
 Section: admin
 Architecture: amd64 i386 armhf arm64
 Depends: lsb-base, udev, xenstore-utils,
-    ${shlibs:Depends}, ${python:Depends}, ${misc:Depends}
+    ${shlibs:Depends}, ${python3:Depends}, ${misc:Depends}
 Suggests: xen-doc
 Description: Xen administrative tools - common files
  The userspace tools to manage a system virtualized through the Xen virtual
@@ -75,7 +74,7 @@ Package: xen-utils-guest
 Section: admin
 Architecture: amd64 i386 armhf arm64
 Depends: xen-utils-4.14,
-    ${shlibs:Depends}, ${python:Depends}, ${misc:Depends}
+    ${shlibs:Depends}, ${python3:Depends}, ${misc:Depends}
 Conflicts: xen-hypervisor-common
 Description: Xen administrative tools - guest files
  The userspace tools to manage a system virtualized through the Xen virtual
@@ -113,7 +112,7 @@ Package: xen-utils-4.14
 Section: admin
 Architecture: amd64 arm64 armhf i386
 Provides: xen-utils
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}, xen-utils-common (>= ${source:Version})
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, xen-utils-common (>= ${source:Version})
 Recommends: bridge-utils, libc6-xen [i386], xen-hypervisor-4.14, qemu-system-x86, grub-xen-host [i386 amd64]
 Suggests: qemu-utils [i386 amd64], seabios [i386 amd64], ovmf
 Description: XEN administrative tools

--- a/debian-vm/debian/rules
+++ b/debian-vm/debian/rules
@@ -137,7 +137,7 @@ make_args_tools= $(make_args_common) \
 	PREPEND_LDFLAGS_XEN_TOOLS='$(dpkg_LDFLAGS)'
 
 %:
-	dh $@ --with=python2
+	dh $@ --with=python3
 
 # Without this, something on stretch passes CFLAGS in the environment
 # to the Xen build system, which then (with 4.11) chokes printing
@@ -255,11 +255,11 @@ override_dh_install:
 	:
 	debian/installsharedlibs
 
-# dh_python2 does not know to look in the funny directory where
+# dh_python3 does not know to look in the funny directory where
 # we put the versioned /usr/lib files including some python scripts.
-override_dh_python2:
-	dh_python2
-	dh_python2 -pxen-utils-$(upstream_version) \
+override_dh_python3:
+	dh_python3
+	dh_python3 -pxen-utils-$(upstream_version) \
 		usr/lib/xen-$(upstream_version)/bin
 
 # We have two init scripts.  (There used to be xend too.)

--- a/debian-vm/debian/scripts/xen-init-list
+++ b/debian-vm/debian/scripts/xen-init-list
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import json
 import re
@@ -65,7 +65,7 @@ class DataSXP(Data):
 
 
 if __name__ == '__main__':
-    p = subprocess.check_output(('xen', 'list', '-l'))
+    p = subprocess.check_output(('xen', 'list', '-l')).decode()
     if p[0] == '(':
         d = DataSXP(p)
     else:

--- a/debian-vm/debian/scripts/xen-init-name
+++ b/debian-vm/debian/scripts/xen-init-name
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import json
 import re
@@ -53,7 +53,7 @@ class DataSXP(Data):
 
 
 if __name__ == '__main__':
-    p = subprocess.check_output(('xen', 'create', '--quiet', '--dryrun', '--defconfig', sys.argv[1]))
+    p = subprocess.check_output(('xen', 'create', '--quiet', '--dryrun', '--defconfig', sys.argv[1])).decode()
     if p[0] == '(':
         d = DataSXP(p)
     else:


### PR DESCRIPTION
There is no point in keeping python2 support anymore.
For Debian bullseye, 'python' package is not installable anymore (there
is 'python2' but we don't want to go this way).

QubesOS/qubes-issues#5297