### PR TITLE
Cleanup parent xenstore dir after device remove

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -45,7 +45,7 @@ build() {
   export OCAML_TOOLS=n
   unset LDFLAGS
 
-  autoreconf
+  autoreconf --install
   ./configure --prefix=/usr \
               --sbindir=/usr/bin \
               --disable-ocamltools \

--- a/patch-libxl-cleanup-remaining-backend-xs-dirs-after-driver.patch
+++ b/patch-libxl-cleanup-remaining-backend-xs-dirs-after-driver.patch
@@ -1,0 +1,42 @@
+From 46f64c98e9248c14a95570f916a04b8b99d306c6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Sun, 8 Nov 2020 13:44:41 +0100
+Subject: [PATCH] libxl: cleanup remaining backend xs dirs after driver domain
+
+When device is removed, backend domain (which may be a driver domain) is
+responsible for removing backend entries from xenstore. But in case of
+driver domain, it has no access to remove all of them - specifically the
+directory named after frontend-id remains. This may accumulate enough to
+exceed xenstore quote of the driver domain, breaking further devices.
+
+Fix this by calling libxl__xs_path_cleanup() on the backend path from
+libxl__device_destroy() in the toolstack domain too. Note
+libxl__device_destroy() is called when the driver domain already removed
+what it can.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libxl/libxl_device.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/tools/libxl/libxl_device.c b/tools/libxl/libxl_device.c
+index 0381c5d50947..3d2051354f6b 100644
+--- a/tools/libxl/libxl_device.c
++++ b/tools/libxl/libxl_device.c
+@@ -763,6 +763,12 @@ int libxl__device_destroy(libxl__gc *gc, libxl__device *dev)
+              * from the backend path.
+              */
+             libxl__xs_path_cleanup(gc, t, be_path);
++        } else if (domid == LIBXL_TOOLSTACK_DOMID && !libxl_only) {
++            /*
++             * Then toolstack domain is in charge of removing the parent
++             * directory if empty already.
++             */
++            libxl__xs_path_cleanup(gc, t, be_path);
+         }
+ 
+         rc = libxl__xs_transaction_commit(gc, &t);
+-- 
+2.25.4
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -138,6 +138,7 @@ Patch630: patch-x86-S3-Fix-Shadow-Stack-resume-path.patch
 Patch631: patch-Revert-xen-credit2-limit-the-max-number-of-CPUs-in-a.patch
 Patch632: patch-x86-S3-Restore-CR4-earlier-during-resume.patch
 Patch633: patch-x86-smpboot-Unconditionally-call-memguard_unguard_stack.patch
+Patch634: patch-libxl-cleanup-remaining-backend-xs-dirs-after-driver.patch
 
 # GCC8 fixes
 Patch714: patch-tools-kdd-mute-spurious-gcc-warning.patch


### PR DESCRIPTION
Driver domain is responsible for xenstore cleanup, but it doesn't have
access to remove (empty) parent directory. Do it in toolstack domain as
the final step.

Fixes QubesOS/qubes-issues#5369 