### PR TITLE
archlinux: fix autoreconf fail on autoconf 2.70

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -45,7 +45,7 @@ build() {
   export OCAML_TOOLS=n
   unset LDFLAGS
 
-  autoreconf
+  autoreconf --install
   ./configure --prefix=/usr \
               --sbindir=/usr/bin \
               --disable-ocamltools \


### PR DESCRIPTION
autoreconf complains and fails to generate the configure script:

```
configure.ac: error: required file 'install-sh' not found
configure.ac:   try running autoreconf --install
```

Archlinux uses autoconf 2.70 as of 2020-12-24 which adds the `--install` option. This change in autoconf behavior is documented under "Noteworthy changes in release 2.70 / More macros use config.sub and config.guess internally" in the autoconf  NEWS[1].

[1]: https://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=blob_plain;f=NEWS;hb=HEAD