### PR TITLE
refactor: add pdev fallback

### DIFF
--- a/patch-0001-libxl-conditionally-allow-PCI-passthrough-on-PV-with.patch
+++ b/patch-0001-libxl-conditionally-allow-PCI-passthrough-on-PV-with.patch
@@ -21,7 +21,8 @@ Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
  tools/libxl/libxl_create.c   |  8 ++++++-
  tools/libxl/libxl_internal.h |  2 ++
  tools/libxl/libxl_pci.c      | 41 ++++++++++++++++++++++++++++++++++--
- 3 files changed, 48 insertions(+), 3 deletions(-)
+ xen/arch/x86/irq.c           | 12 +++++++++++-
+ 4 files changed, 59 insertions(+), 4 deletions(-)
 
 diff --git a/tools/libxl/libxl_create.c b/tools/libxl/libxl_create.c
 index 2814818e34d2..90aa0a35cdc8 100644
@@ -119,6 +120,30 @@ index bc5843b13701..87fbce653d81 100644
  int libxl__device_pci_setdefault(libxl__gc *gc, uint32_t domid,
                                   libxl_device_pci *pci, bool hotplug)
  {
+diff --git a/xen/arch/x86/irq.c b/xen/arch/x86/irq.c
+index 37c8628..42c6fde 100644
+--- a/xen/arch/x86/irq.c
++++ b/xen/arch/x86/irq.c
+@@ -2165,8 +2165,18 @@ int map_domain_pirq(
+             goto done;
+ 
+         pdev = pci_get_pdev_by_domain(d, msi->seg, msi->bus, msi->devfn);
+-        if ( !pdev )
++        if ( !pdev ) {
++            if (
++                // condition 1: !iommu_enabled
++                // condition 2: type == LIBXL_DOMAIN_TYPE_PV
++                // condition 3: libxl__is_insecure_pv_passthrough_enabled
++            ) {
++                pdev = pci_get_pdev(msi->seg, msi->bus, msi->devfn);
++            }
++        }
++        if ( !pdev ) {
+             goto done;
++        }
+ 
+         ret = pci_enable_msi(msi, &msi_desc);
+         if ( ret )
 -- 
 2.25.4
 


### PR DESCRIPTION
This PR intends to extend `patch-0001-libxl-conditionally-allow-PCI-passthrough-on-PV-with.patch` in order to allow using `pci_get_pdev` when `pci_get_pdev_by_domain` was unsuccessful, as it seems that update broke something that incorrectly reports the owner of a device thus rendering `pci_get_pdev_by_domain` useless (see https://github.com/QubesOS/qubes-issues/issues/3217#issuecomment-348042584)

I see the base patch already includes some utilities to make this work, but I would like to ask before proceed:

- should we import `libxl__is_insecure_pv_passthrough_enabled` or redefine in this file?
- should `iommu_enabled` be stored globally so it's easier to get (as it will probably be used in more patches)
- is `type == LIBXL_DOMAIN_TYPE_PV` check redundant in this exact location?

I'm not very knowledgeable in `C` but given some advise regarding these questions I can complete this PR. Also if you see that this PR should be another flag and not be used implicitly with `qubes.enable_insecure_pv_passthrough`, please let me know.