### PR TITLE
Add a patch with gcc11 fixes

### DIFF
--- a/patch-gcc11-fixes.patch
+++ b/patch-gcc11-fixes.patch
@@ -1,0 +1,64 @@
+--- xen-4.14.0/xen/include/crypto/vmac.h.orig	2020-07-23 16:07:51.000000000 +0100
++++ xen-4.14.0/xen/include/crypto/vmac.h	2020-10-24 15:45:49.246467465 +0100
+@@ -142,7 +142,7 @@
+ 
+ #define vmac_update vhash_update
+ 
+-void vhash_update(unsigned char m[],
++void vhash_update(uint8_t *m,
+           unsigned int mbytes,
+           vmac_ctx_t *ctx);
+ 
+--- xen-4.14.0/tools/libs/foreignmemory/linux.c.orig	2020-07-23 16:07:51.000000000 +0100
++++ xen-4.14.0/tools/libs/foreignmemory/linux.c	2020-10-25 21:36:00.982040566 +0000
+@@ -162,7 +162,7 @@
+ void *osdep_xenforeignmemory_map(xenforeignmemory_handle *fmem,
+                                  uint32_t dom, void *addr,
+                                  int prot, int flags, size_t num,
+-                                 const xen_pfn_t arr[/*num*/], int err[/*num*/])
++                                 const xen_pfn_t arr[num], int err[num])
+ {
+     int fd = fmem->fd;
+     privcmd_mmapbatch_v2_t ioctlx;
+--- xen-4.14.0/tools/libs/foreignmemory/minios.c.orig	2020-07-23 16:07:51.000000000 +0100
++++ xen-4.14.0/tools/libs/foreignmemory/minios.c	2020-10-26 22:36:12.423883688 +0000
+@@ -42,7 +42,7 @@
+ void *osdep_xenforeignmemory_map(xenforeignmemory_handle *fmem,
+                                  uint32_t dom, void *addr,
+                                  int prot, int flags, size_t num,
+-                                 const xen_pfn_t arr[/*num*/], int err[/*num*/])
++                                 const xen_pfn_t arr[num], int err[num])
+ {
+     unsigned long pt_prot = 0;
+     if (prot & PROT_READ)
+diff --git a/xen/arch/x86/tboot.c b/xen/arch/x86/tboot.c
+index 320e06f..618ae92 100644
+--- a/xen/arch/x86/tboot.c
++++ b/xen/arch/x86/tboot.c
+@@ -91,7 +91,7 @@ static void __init tboot_copy_memory(unsigned char *va, uint32_t size,
+ 
+ void __init tboot_probe(void)
+ {
+-    tboot_shared_t *tboot_shared;
++    tboot_shared_t * volatile tboot_shared;
+ 
+     /* Look for valid page-aligned address for shared page. */
+     if ( !opt_tboot_pa || (opt_tboot_pa & ~PAGE_MASK) )
+diff --git a/xen/arch/x86/x86_emulate/x86_emulate.c b/xen/arch/x86/x86_emulate/x86_emulate.c
+index 84bb8e0..6ecf5db 100644
+--- a/xen/arch/x86/x86_emulate/x86_emulate.c
++++ b/xen/arch/x86/x86_emulate/x86_emulate.c
+@@ -725,9 +725,9 @@ union vex {
+ #define copy_VEX(ptr, vex) ({ \
+     if ( !mode_64bit() ) \
+         (vex).reg |= 8; \
+-    (ptr)[0 - PFX_BYTES] = ext < ext_8f08 ? 0xc4 : 0x8f; \
+-    (ptr)[1 - PFX_BYTES] = (vex).raw[0]; \
+-    (ptr)[2 - PFX_BYTES] = (vex).raw[1]; \
++    ((volatile uint8_t *)ptr)[0 - PFX_BYTES] = ext < ext_8f08 ? 0xc4 : 0x8f; \
++    ((volatile uint8_t *)ptr)[1 - PFX_BYTES] = (vex).raw[0]; \
++    ((volatile uint8_t *)ptr)[2 - PFX_BYTES] = (vex).raw[1]; \
+     container_of((ptr) + 1 - PFX_BYTES, typeof(vex), raw[0]); \
+ })
+ 
+

--- a/series-vm.conf
+++ b/series-vm.conf
@@ -8,3 +8,4 @@ patch-Define-build-dates-time-based-on-SOURCE_DATE_EPOCH.patch
 patch-docs-rename-DATE-to-PANDOC_REL_DATE-and-allow-to-spe.patch
 patch-docs-xen-headers-use-alphabetical-sorting-for-incont.patch
 patch-Strip-build-path-directories-in-tools-xen-and-xen-ar.patch
+patch-gcc11-fixes.patch


### PR DESCRIPTION
Without this patch, builds of the Archlinux package fail: [build-error.log](https://github.com/QubesOS/qubes-vmm-xen/files/6548501/build-error.log)

The patch was copied from https://src.fedoraproject.org/rpms/xen/blob/rawhide/f/xen.gcc11.fixes.patch - I found the link from some discussions and it seems to work, but I don't actually understand the problems or fixes :man_shrugging: 