### PR TITLE
Revert "rpm: do not load xen-acpi-processor with systemd-modules-load"

### DIFF
--- a/xen.modules-load.conf
+++ b/xen.modules-load.conf
@@ -4,7 +4,6 @@ xen-gntalloc
 xen-blkback
 xen-pciback
 xen-privcmd
-# loaded with /etc/sysconfig/modules/cpufreq-xen.modules
-#xen-acpi-processor
+xen-acpi-processor
 # Not used in Qubes dom0
 #xen-netback


### PR DESCRIPTION
We have newer systemd now with the -ENODEV handling fixed.
This reverts commit 893fefac99467f4612b5879b737ed2a5ee1cda57.

Fixes QubesOS/qubes-issues#6465