### PR TITLE
libxl: correctly detect backend_domid when detaching a device

### DIFF
--- a/patch-libxl-do-not-require-filling-backend_domid-to-remove.patch
+++ b/patch-libxl-do-not-require-filling-backend_domid-to-remove.patch
@@ -1,0 +1,100 @@
+From 7b6fe3e7e709aa8bea6ba607f0079717a4b69a20 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 8 Nov 2021 03:50:35 +0100
+Subject: [PATCH] libxl: do not require filling backend_domid to remove device
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+Existing device can be unambiguously identified by (domid, devtype,
+devid), do not require backend_domid (or _name) to be filled. This
+especially helps detaching a device - which with not filled (or invalid)
+backend_domid would seemingly succeed, while in fact the backend
+wouldn't be cleaned up.
+
+Try to fill the backend_domid only if not explicitly given (left as 0,
+as libxl_device_disk_init() does). This allows the function to still
+work outside the toolstack domain - specifically in the backend domain
+as part of the xendriverdomain service.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libxl/libxl_device.c   | 32 ++++++++++++++++++++++++++++++-
+ tools/libxl/libxl_internal.h |  1 +
+ 2 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/tools/libxl/libxl_device.c b/tools/libxl/libxl_device.c
+index 36c4e41e4dc1..5d92b6a75564 100644
+--- a/tools/libxl/libxl_device.c
++++ b/tools/libxl/libxl_device.c
+@@ -75,6 +75,25 @@ char *libxl__device_libxl_path(libxl__gc *gc, libxl__device *device)
+                      device->devid);
+ }
+ 
++const char *libxl__live_device_backend_path(libxl__gc *gc, libxl__device *device)
++{
++    const char *libxl_dom_path = libxl__device_libxl_path(gc, device);
++    const char *be_path;
++    int rc;
++
++    rc = libxl__xs_read_checked(gc, XBT_NULL,
++                                GCSPRINTF("%s/backend", libxl_dom_path),
++                                &be_path);
++    if (rc)
++        /* read failure */
++        return NULL;
++    if (be_path)
++        return be_path;
++
++    /* fallback to constructing the path */
++    return libxl__device_backend_path(gc, device);
++}
++
+ char *libxl__domain_device_libxl_path(libxl__gc *gc,  uint32_t domid, uint32_t devid,
+                                       libxl__device_kind device_kind)
+ {
+@@ -932,7 +951,7 @@ void libxl__initiate_device_generic_remove(libxl__egc *egc,
+ {
+     STATE_AO_GC(aodev->ao);
+     xs_transaction_t t = 0;
+-    char *be_path = libxl__device_backend_path(gc, aodev->dev);
++    const char *be_path = libxl__live_device_backend_path(gc, aodev->dev);
+     char *state_path = GCSPRINTF("%s/state", be_path);
+     char *online_path = GCSPRINTF("%s/online", be_path);
+     const char *state;
+@@ -940,6 +959,17 @@ void libxl__initiate_device_generic_remove(libxl__egc *egc,
+     uint32_t my_domid, domid = aodev->dev->domid;
+     int rc = 0;
+ 
++    if (!aodev->dev->backend_domid) {
++        /*
++         * Deduce backend_domid if not given explicitly (left as 0), but don't
++         * override explicit non-zero value, to work also in the backend domain
++         * (not a toolstack domain).
++         */
++        rc = libxl__backendpath_parse_domid(gc, be_path,
++                                            &aodev->dev->backend_domid);
++        if (rc) goto out;
++    }
++
+     libxl_dominfo_init(&info);
+ 
+     rc = libxl__get_domid(gc, &my_domid);
+diff --git a/tools/libxl/libxl_internal.h b/tools/libxl/libxl_internal.h
+index 0b4671318c82..b22c739643af 100644
+--- a/tools/libxl/libxl_internal.h
++++ b/tools/libxl/libxl_internal.h
+@@ -1525,6 +1525,7 @@ _hidden char *libxl__domain_device_backend_path(libxl__gc *gc, uint32_t backend_
+ _hidden char *libxl__device_libxl_path(libxl__gc *gc, libxl__device *device);
+ _hidden char *libxl__domain_device_libxl_path(libxl__gc *gc, uint32_t domid, uint32_t devid,
+                                               libxl__device_kind device_kind);
++_hidden const char *libxl__live_device_backend_path(libxl__gc *gc, libxl__device *device);
+ _hidden int libxl__parse_backend_path(libxl__gc *gc, const char *path,
+                                       libxl__device *dev);
+ _hidden int libxl__console_tty_path(libxl__gc *gc, uint32_t domid, int cons_num,
+-- 
+2.31.1
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -140,6 +140,7 @@ Patch634: patch-libxl-cleanup-remaining-backend-xs-dirs-after-driver.patch
 Patch635: patch-libxl-user-defined-max_maptrack_frames.patch
 Patch636: patch-autoconf-fix-handling-absolute-PYTHON-path.patch
 Patch637: patch-0001-x86-xstate-reset-cached-register-values-on-resume.patch
+Patch638: patch-libxl-do-not-require-filling-backend_domid-to-remove.patch
 
 # GCC8 fixes
 Patch714: patch-tools-kdd-mute-spurious-gcc-warning.patch


### PR DESCRIPTION
libvirt does not set backend_domid when detaching a disk device (it does
backend_name, but it isn't resolved on detach). Instead of resolving the
backend_name, use other information (that is sufficient already) to
deduce backend_domid.

The patch is upstreamable, but likely only after Xen 4.16 will be
released (as in: after the pre-release code freeze).

Fixes QubesOS/qubes-issues#6996