### PR TITLE
spec: install missing auxiliary files for autoreconf

### DIFF
--- a/xen.spec.in
+++ b/xen.spec.in
@@ -457,7 +457,7 @@ CONFIG_EXTRA="$CONFIG_EXTRA --disable-pvshim"
 %endif
 CONFIG_EXTRA="$CONFIG_EXTRA --with-extra-qemuu-configure-args='--disable-spice'"
 export PATH="/usr/bin:$PATH"
-autoreconf
+autoreconf -i
 # END QUBES SPECIFIC PART
 ./configure --prefix=%{_prefix} --libdir=%{_libdir} --libexecdir=%{_libexecdir} --with-system-seabios=%{seabiosloc} --with-linux-backend-modules="xen-evtchn xen-gntdev xen-gntalloc xen-blkback xen-netback xen-pciback xen-scsiback xen-acpi-processor" $CONFIG_EXTRA
 make %{?_smp_mflags} %{?ocaml_flags} prefix=/usr tools


### PR DESCRIPTION
QubesOS/qubes-issues#6982