### PR TITLE
Makefile.builder: restrict build for BACKEND_VMM=xen

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,3 +1,4 @@
+ifeq ($(BACKEND_VMM),xen)
 ifeq ($(PACKAGE_SET),dom0)
   RPM_SPEC_FILES := xen.spec
 
@@ -14,6 +15,7 @@ else ifeq ($(PACKAGE_SET),vm)
     DEBIAN_BUILD_DIRS := debian-vm/debian
     SOURCE_COPY_IN := source-debian-xen-copy-in
   endif
+endif
 endif
 
 NO_ARCHIVE := 1


### PR DESCRIPTION
QubesOS/qubes-issues#7051