### PR TITLE
Prohibit domid reuse

### DIFF
--- a/patch-Always-allocate-domid-sequentially-and-do-not-reuse-.patch
+++ b/patch-Always-allocate-domid-sequentially-and-do-not-reuse-.patch
@@ -1,0 +1,64 @@
+From e950e89764712618533e27cf42c017fe5ae8dc10 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Fri, 3 Dec 2021 21:13:23 +0100
+Subject: [PATCH] Always allocate domid sequentially, and do not reuse them
+
+While domid wrapping around is unlikely on Qubes, make sure it wont
+happen, to avoid various corner cases.
+---
+ xen/common/domctl.c | 34 ++++++++++++----------------------
+ 1 file changed, 12 insertions(+), 22 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 2b25653b49..7afae44604 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -489,32 +489,22 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+     case XEN_DOMCTL_createdomain:
+     {
+         domid_t        dom;
+-        static domid_t rover = 0;
++        static domid_t rover = 1;
+ 
+-        dom = op->domain;
+-        if ( (dom > 0) && (dom < DOMID_FIRST_RESERVED) )
+-        {
+-            ret = -EEXIST;
+-            if ( !is_free_domid(dom) )
+-                break;
+-        }
+-        else
+-        {
+-            for ( dom = rover + 1; dom != rover; dom++ )
+-            {
+-                if ( dom == DOMID_FIRST_RESERVED )
+-                    dom = 1;
+-                if ( is_free_domid(dom) )
+-                    break;
+-            }
+-
+-            ret = -ENOMEM;
+-            if ( dom == rover )
+-                break;
++        /* Refuse explicit domid via op->domain */
++        if ( (op->domain > 0) && (op->domain < DOMID_FIRST_RESERVED) )
++            return -EINVAL;
+ 
+-            rover = dom;
++        if ( rover >= DOMID_FIRST_RESERVED ) {
++            printk(XENLOG_ERR
++                   "domctl: out of available domid values, reboot the system\n");
++            return -ENOMEM;
+         }
+ 
++        dom = rover++;
++        if ( ! is_free_domid(dom) )
++            return -EEXIST;
++
+         d = domain_create(dom, &op->u.createdomain, false);
+         if ( IS_ERR(d) )
+         {
+-- 
+2.31.1
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -169,6 +169,7 @@ Patch1014: patch-allow-kernelopts-stubdom.patch
 Patch1015: patch-libxl-readonly-disk-scsi.patch
 Patch1016: patch-tools-xenconsole-replace-ESC-char-on-xenconsole-outp.patch
 Patch1017: patch-libxl-disable-vkb-by-default.patch
+Patch1018: patch-Always-allocate-domid-sequentially-and-do-not-reuse-.patch
 
 Patch1020: patch-stubdom-linux-config-qubes-gui.patch
 Patch1021: patch-stubdom-linux-libxl-do-not-force-qdisk-backend-for-cdrom.patch


### PR DESCRIPTION
When Xen runs out of domid to allocate, require a system reboot, instead
of reusing them.