### PR TITLE
TBD: Add partially Intel GVT-g support (xengt device)

### DIFF
--- a/patch-gvt-hvmloader.patch
+++ b/patch-gvt-hvmloader.patch
@@ -1,0 +1,125 @@
+# HG changeset patch
+# Parent 1ad1537e8bb543aafd9f41afe5d5b475a34c59fa
+
+diff --git a/tools/firmware/hvmloader/config.h b/tools/firmware/hvmloader/config.h
+index 844120b..fb05f53 100644
+--- a/tools/firmware/hvmloader/config.h
++++ b/tools/firmware/hvmloader/config.h
+@@ -4,7 +4,7 @@
+ #include <stdint.h>
+ #include <stdbool.h>
+ 
+-enum virtual_vga { VGA_none, VGA_std, VGA_cirrus, VGA_pt };
++enum virtual_vga { VGA_none, VGA_std, VGA_cirrus, VGA_pt, VGA_vgt };
+ extern enum virtual_vga virtual_vga;
+ 
+ extern unsigned long igd_opregion_pgbase;
+diff --git a/tools/firmware/hvmloader/pci.c b/tools/firmware/hvmloader/pci.c
+index ba56b10..3290696 100644
+--- a/tools/firmware/hvmloader/pci.c
++++ b/tools/firmware/hvmloader/pci.c
+@@ -23,6 +23,7 @@
+ #include "hypercall.h"
+ #include "config.h"
+ #include "pci_regs.h"
++#include "vgt.h"
+ 
+ #include <xen/memory.h>
+ #include <xen/hvm/ioreq.h>
+@@ -84,6 +85,7 @@ void pci_setup(void)
+     uint16_t class, vendor_id, device_id;
+     unsigned int bar, pin, link, isa_irq;
+     uint8_t pci_devfn_decode_type[256] = {};
++    uint8_t intel_gpu_present = 0;
+ 
+     /* Resources assignable to PCI devices via BARs. */
+     struct resource {
+@@ -163,6 +165,9 @@ void pci_setup(void)
+         ASSERT((devfn != PCI_ISA_DEVFN) ||
+                ((vendor_id == 0x8086) && (device_id == 0x7000)));
+ 
++        if (( vendor_id == 0x8086 ) && (class == 0x0300 || class == 0x0380))
++            intel_gpu_present = 1;
++
+         switch ( class )
+         {
+         case 0x0300:
+@@ -541,6 +546,36 @@ void pci_setup(void)
+ 
+     if ( vga_devfn != 256 )
+     {
++        if ( intel_gpu_present )
++        {
++            uint32_t bar = pci_readl(vga_devfn, PCI_BASE_ADDRESS_0)
++                                        & PCI_BASE_ADDRESS_MEM_MASK;
++
++            void *pvinfo = (void *)bar + VGT_PVINFO_PAGE;
++            uint64_t *magic = pvinfo;
++
++            if (*magic == VGT_MAGIC) {
++		uint32_t vga_bar = pci_readl(vga_devfn, PCI_BASE_ADDRESS_5)
++						& PCI_BASE_ADDRESS_MEM_MASK;
++                /*
++                 * Found VGT device, and use standard VGA bios.
++                 */
++                virtual_vga = VGA_vgt;
++
++                /* XXX: we use this hack to tell vGT driver the
++                 * top of <4G mem, so vGT can avoid unnecessary
++                 * attempts to map the mem hole. This optimization
++                 * can speed up guest bootup time and improve Win7
++                 * SMP guest's stability.
++                 * NOTE: here we're actually trying to write 32 bits
++                 * into VENDOR_ID and DEVICE_ID -- we assume normally
++                 * sane codes in guest won't do this...
++                 */
++                 pci_writel(vga_devfn, PCI_VENDOR_ID, hvm_info->low_mem_pgend);
++		 /* XXX: Let QEMU legacy VGA emulator know the vga bar address*/
++                 pci_writel(0, 0xf8, vga_bar);
++            }
++        }
+         /*
+          * VGA registers live in I/O space so ensure that primary VGA
+          * has IO enabled, even if there is no I/O BAR on that
+diff --git a/tools/firmware/hvmloader/rombios.c b/tools/firmware/hvmloader/rombios.c
+index 9a5ddcf..6d45db2 100644
+--- a/tools/firmware/hvmloader/rombios.c
++++ b/tools/firmware/hvmloader/rombios.c
+@@ -78,6 +78,7 @@ static void rombios_load_roms(void)
+                vgabios_cirrusvga, sizeof(vgabios_cirrusvga));
+         vgabios_sz = round_option_rom(sizeof(vgabios_cirrusvga));
+         break;
++    case VGA_vgt:
+     case VGA_std:
+         printf("Loading Standard VGABIOS ...\n");
+         memcpy((void *)VGABIOS_PHYSICAL_ADDRESS,
+diff --git a/tools/firmware/hvmloader/vgt.h b/tools/firmware/hvmloader/vgt.h
+new file mode 100644
+index 0000000..f5b3f34
+--- /dev/null
++++ b/tools/firmware/hvmloader/vgt.h
+@@ -0,0 +1,24 @@
++/*
++ * Copyright (c) 2012-2013, Intel Corporation.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License along with
++ * this program; if not, write to the Free Software Foundation, Inc.,
++ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
++ */
++
++#ifndef _VGT_DEVTABLE_H
++#define _VGT_DEVTABLE_H
++
++#define VGT_PVINFO_PAGE 	0x78000
++#define VGT_MAGIC		0x4776544776544776    /* 'vGTvGTvG' */
++
++#endif  /* _VGT_DEVTABLE_H */

--- a/patch-gvt-hypercall-XENMEM_get_mfn_from_pfn.patch
+++ b/patch-gvt-hypercall-XENMEM_get_mfn_from_pfn.patch
@@ -1,0 +1,126 @@
+From 8aca1e3dfa347dafdf7df482bb1267de46bc572a Mon Sep 17 00:00:00 2001
+From: Wei Ye <wei.ye@intel.com>
+Date: Thu, 21 Aug 2014 03:45:38 +0800
+Subject: [PATCH 07/18] hypercall: XENMEM_get_mfn_from_pfn
+
+Suppose that we should find an existing method to achieve the same
+goal.
+
+Signed-off-by: Wei Ye <wei.ye@intel.com>
+Signed-off-by: Yu Zhang <yu.c.zhang@intel.com>
+diff --git a/xen/arch/x86/mm.c b/xen/arch/x86/mm.c
+index 5591a4d..0702172 100644
+--- a/xen/arch/x86/mm.c
++++ b/xen/arch/x86/mm.c
+@@ -4459,6 +4459,61 @@ int arch_acquire_resource(struct domain *d, unsigned int type,
+     return rc;
+ }
+ 
++static int get_mfn_from_pfn(XEN_GUEST_HANDLE(xen_get_mfn_from_pfn_t) arg)
++{
++    struct xen_get_mfn_from_pfn cmd_info;
++    struct domain *d;
++    int rc=0, i;
++    xen_pfn_t *pfns = NULL;
++    xen_pfn_t pfn;
++    struct p2m_domain *p2m;
++    p2m_type_t t;
++
++    if ( !is_hardware_domain(current->domain) )
++        return -EPERM;
++
++    if ( copy_from_guest(&cmd_info, arg, 1) )
++        return -EFAULT;
++
++    d = rcu_lock_domain_by_any_id(cmd_info.domid);
++    if ( d == NULL )
++        return -ESRCH;
++
++    /* sanity check for security */
++    if (cmd_info.nr_pfns > 2048 )
++        return -ENOMEM;
++
++    pfns = xmalloc_array(xen_pfn_t, cmd_info.nr_pfns);
++    if (pfns == NULL)
++        return -ENOMEM;
++
++    if (copy_from_guest(pfns, cmd_info.pfn_list, cmd_info.nr_pfns)){
++        rc = -EFAULT;
++        goto out;
++    }
++
++    p2m = p2m_get_hostp2m(d);
++    for(i=0; i < cmd_info.nr_pfns; i++){
++        pfn = pfns[i];
++        pfns[i] = mfn_x(get_gfn_query(d, pfn, &t));
++		if(pfns[i] == mfn_x(INVALID_MFN)){
++			rc = -EINVAL;
++			goto out;
++		}
++		put_gfn(d, pfn);
++    }
++
++    if (copy_to_guest(cmd_info.pfn_list, pfns, cmd_info.nr_pfns)){
++        rc = -EFAULT;
++        goto out;
++    }
++
++out:
++    rcu_unlock_domain(d);
++    xfree(pfns);
++    return rc;
++}
++
+ long arch_memory_op(unsigned long cmd, XEN_GUEST_HANDLE_PARAM(void) arg)
+ {
+     int rc;
+@@ -4689,6 +4744,15 @@ long arch_memory_op(unsigned long cmd, XEN_GUEST_HANDLE_PARAM(void) arg)
+     }
+ #endif
+ 
++#ifdef __x86_64__
++    case XENMEM_get_sharing_freed_pages:
++        return mem_sharing_get_nr_saved_mfns();
++#endif
++
++    case XENMEM_get_mfn_from_pfn:
++        return get_mfn_from_pfn(guest_handle_cast(arg, xen_get_mfn_from_pfn_t));
++        break;
++
+     default:
+         return subarch_memory_op(cmd, arg);
+     }
+diff --git a/xen/include/public/memory.h b/xen/include/public/memory.h
+index 4ad7f6d..5567d95 100644
+--- a/xen/include/public/memory.h
++++ b/xen/include/public/memory.h
+@@ -677,6 +677,29 @@ DEFINE_XEN_GUEST_HANDLE(xen_mem_acquire_resource_t);
+ DEFINE_XEN_GUEST_HANDLE(xen_mem_acquire_resource_t);
+ 
+ /*
++ * Translate the given guest PFNs to MFNs
++ */
++#define XENMEM_get_mfn_from_pfn    29
++struct xen_get_mfn_from_pfn {
++    /*
++     * Pointer to buffer to fill with list of pfn.
++     * for IN, it contains the guest PFN that need to translated
++     * for OUT, it contains the translated MFN. or INVALID_MFN if no valid translation
++     */
++    XEN_GUEST_HANDLE(xen_pfn_t) pfn_list;
++
++    /*
++     * IN: Size of the pfn_array.
++     */
++    unsigned int nr_pfns;
++
++    /* IN: which domain */
++    domid_t domid;
++};
++typedef struct xen_get_mfn_from_pfn xen_get_mfn_from_pfn_t;
++DEFINE_XEN_GUEST_HANDLE(xen_get_mfn_from_pfn_t);
++
++/*
+  * XENMEM_get_vnumainfo used by guest to get
+  * vNUMA topology from hypervisor.
+  */

--- a/patch-gvt-libxl-init.patch
+++ b/patch-gvt-libxl-init.patch
@@ -1,0 +1,161 @@
+diff -ur xen-4.14.0-orig/tools/libxl/libxl_create.c xen-4.14.0-new/tools/libxl/libxl_create.c
+--- xen-4.14.0-orig/tools/libxl/libxl_create.c	2020-07-23 18:07:51.000000000 +0300
++++ xen-4.14.0-new/tools/libxl/libxl_create.c	2020-08-31 17:41:42.587563737 +0300
+@@ -27,6 +27,36 @@
+ 
+ #include <xen-xsm/flask/flask.h>
+ 
++/* The format of the string is:
++ * domid,aperture_size,gm_size,fence_size. This means we want the vgt
++ * driver to create a vgt instance for Domain domid with the required
++ * parameters. NOTE: aperture_size and gm_size are in MB.
++ */
++static void domcreate_vgt_instance(libxl__gc *gc, uint32_t domid,
++                              libxl_domain_build_info *b_info)
++{
++    const char *path = "/sys/kernel/vgt/control/create_vgt_instance";
++    FILE *vgt_file;
++    int low_gm = b_info->u.hvm.vgt_low_gm_sz ?: 64;
++    int high_gm = b_info->u.hvm.vgt_high_gm_sz ?: 448;
++    int fence = b_info->u.hvm.vgt_fence_sz ?: 4;
++
++    if ((vgt_file = fopen(path, "w")) == NULL) {
++        LOGD(ERROR, domid, "vGT: fopen failed\n");
++        return;
++    }
++
++    LOGD(INFO, domid, "vGT: fprintf %u,%u,%u,%u,-1,0\n", 
++		    domid, low_gm, high_gm, fence);
++    
++    if (fprintf(vgt_file, "%u,%u,%u,%u,-1,0\n",
++               domid, low_gm, high_gm, fence) < 0)
++        LOGD(ERROR, domid, "vGT: fprintf failed %d\n", errno);
++    
++    fclose(vgt_file);
++    return;
++}
++
+ int libxl__domain_create_info_setdefault(libxl__gc *gc,
+                                          libxl_domain_create_info *c_info,
+                                          const libxl_physinfo *info)
+@@ -338,6 +368,7 @@
+                     return ERROR_INVAL;
+                 }
+                 break;
++            case LIBXL_VGA_INTERFACE_TYPE_XENGT:
+             case LIBXL_VGA_INTERFACE_TYPE_CIRRUS:
+             default:
+                 if (b_info->video_memkb == LIBXL_MEMKB_DEFAULT)
+@@ -1722,6 +1753,9 @@
+         if ( ret )
+             goto error_out;
+ 
++	if (d_config->b_info.u.hvm.vga.kind == LIBXL_VGA_INTERFACE_TYPE_XENGT)
++            domcreate_vgt_instance(gc, domid, &d_config->b_info);
++
+         return;
+     }
+     case LIBXL_DOMAIN_TYPE_PV:
+diff -ur xen-4.14.0-orig/tools/libxl/libxl_dm.c xen-4.14.0-new/tools/libxl/libxl_dm.c
+--- xen-4.14.0-orig/tools/libxl/libxl_dm.c	2020-07-23 18:07:51.000000000 +0300
++++ xen-4.14.0-new/tools/libxl/libxl_dm.c	2020-08-31 17:41:42.588563739 +0300
+@@ -1446,6 +1446,9 @@
+                 GCSPRINTF("qxl-vga,vram_size_mb=%"PRIu64",ram_size_mb=%"PRIu64,
+                 (b_info->video_memkb/2/1024), (b_info->video_memkb/2/1024) ) );
+             break;
++        case LIBXL_VGA_INTERFACE_TYPE_XENGT:
++            flexarray_vappend(dm_args, "-vga", "xengt", NULL);
++	     break;
+         default:
+             LOGD(ERROR, guest_domid, "Invalid emulated video card specified");
+             return ERROR_INVAL;
+diff -ur xen-4.14.0-orig/tools/libxl/libxl_domain.c xen-4.14.0-new/tools/libxl/libxl_domain.c
+--- xen-4.14.0-orig/tools/libxl/libxl_domain.c	2020-07-23 18:07:51.000000000 +0300
++++ xen-4.14.0-new/tools/libxl/libxl_domain.c	2020-08-31 17:42:35.352685370 +0300
+@@ -1078,6 +1078,30 @@
+ static void destroy_finish_check(libxl__egc *egc,
+                                  libxl__domain_destroy_state *dds);
+ 
++/* We don't care the return value:
++ * 1) the guest may not be a VGT guest;
++ * 2) normally when a VGT guest shutdown, the ioemu has already tried to
++ * destroy the vgt instance and we shouldn't come here by "xl dest dom_id".
++ * 3) we come here because the ioemu didn't destroy the vgt instance
++ * successfully(e.g., ioemu exits abnormally) or we want to kill the guest by
++ * force while it's running. In this case, we still try our best to destroy
++ * the vgt instance.
++ */
++static void destroy_vgt_instance(int domid)
++{
++    const char *path = "/sys/kernel/vgt/control/create_vgt_instance";
++    FILE *vgt_file;
++
++    if (domid <= 0)
++        return;
++
++    if ((vgt_file = fopen(path, "w")) == NULL)
++        return;
++
++    (void)fprintf(vgt_file, "%d\n", -domid);
++    (void)fclose(vgt_file);
++}
++
+ void libxl__domain_destroy(libxl__egc *egc, libxl__domain_destroy_state *dds)
+ {
+     STATE_AO_GC(dds->ao);
+@@ -1547,6 +1571,8 @@
+     }
+     libxl__userdata_destroyall(gc, domid);
+ 
++    destroy_vgt_instance(domid);
++
+     libxl__unlock_file(lock);
+ 
+     /* Clean up qemu-save and qemu-resume files. They are
+diff -ur xen-4.14.0-orig/tools/libxl/libxl_types.idl xen-4.14.0-new/tools/libxl/libxl_types.idl
+--- xen-4.14.0-orig/tools/libxl/libxl_types.idl	2020-07-23 18:07:51.000000000 +0300
++++ xen-4.14.0-new/tools/libxl/libxl_types.idl	2020-08-31 17:41:42.590563744 +0300
+@@ -38,6 +38,7 @@
+ #
+ 
+ MemKB = UInt(64, init_val = "LIBXL_MEMKB_DEFAULT", json_gen_fn = "libxl__uint64_gen_json")
++VgtInt = UInt(32, init_val = "0UL")
+ 
+ #
+ # Constants / Enumerations
+@@ -220,6 +221,7 @@
+     (2, "STD"),
+     (3, "NONE"),
+     (4, "QXL"),
++    (5, "XENGT"),
+     ], init_val = "LIBXL_VGA_INTERFACE_TYPE_UNKNOWN")
+ 
+ libxl_vendor_device = Enumeration("vendor_device", [
+@@ -590,6 +592,9 @@
+                                        ("hdtype",           libxl_hdtype),
+                                        ("nographic",        libxl_defbool),
+                                        ("vga",              libxl_vga_interface_info),
++                                       ("vgt_low_gm_sz",    VgtInt),
++                                       ("vgt_high_gm_sz",   VgtInt),
++                                       ("vgt_fence_sz",     VgtInt),
+                                        ("vnc",              libxl_vnc_info),
+                                        # keyboard layout, default is en-us keyboard
+                                        ("keymap",           string),
+diff -pruN xen-4.14.0/tools/xl/xl_parse.c xen-4.14.0.new/tools/xl/xl_parse.c
+--- xen-4.14.0/tools/xl/xl_parse.c	2020-07-23 18:07:51.000000000 +0300
++++ xen-4.14.0.new/tools/xl/xl_parse.c	2020-09-01 17:07:05.821572572 +0300
+@@ -2590,6 +2590,14 @@ skip_usbdev:
+                 b_info->u.hvm.vga.kind = LIBXL_VGA_INTERFACE_TYPE_NONE;
+             } else if (!strcmp(buf, "qxl")) {
+                 b_info->u.hvm.vga.kind = LIBXL_VGA_INTERFACE_TYPE_QXL;
++            } else if (!strcmp(buf, "xengt")) {
++                b_info->u.hvm.vga.kind = LIBXL_VGA_INTERFACE_TYPE_XENGT;
++        	if (!xlu_cfg_get_long(config, "vgt_low_gm_sz", &l, 0))
++            	    b_info->u.hvm.vgt_low_gm_sz = l;
++        	if (!xlu_cfg_get_long(config, "vgt_high_gm_sz", &l, 0))
++                    b_info->u.hvm.vgt_high_gm_sz = l;
++        	if (!xlu_cfg_get_long(config, "vgt_fence_sz", &l, 0))
++            	    b_info->u.hvm.vgt_fence_sz = l;
+             } else {
+                 fprintf(stderr, "Unknown vga \"%s\" specified\n", buf);
+                 exit(1);

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -81,6 +81,7 @@ Source2: %{name}.logrotate
 # .config file for xen hypervisor
 Source3: config
 Source32: xen.modules-load.conf
+Provides: xen-gvt
 
 # Out-of-tree patches.
 #
@@ -190,6 +191,11 @@ Patch1053: patch-docs-rename-DATE-to-PANDOC_REL_DATE-and-allow-to-spe.patch
 Patch1054: patch-docs-xen-headers-use-alphabetical-sorting-for-incont.patch
 Patch1055: patch-Strip-build-path-directories-in-tools-xen-and-xen-ar.patch
 
+# GVT-g
+Patch1200: patch-gvt-hypercall-XENMEM_get_mfn_from_pfn.patch
+Patch1201: patch-gvt-hvmloader.patch
+Patch1202: patch-gvt-libxl-init.patch
+
 %if %build_qemutrad
 BuildRequires: libidn-devel zlib-devel SDL-devel curl-devel
 BuildRequires: libX11-devel gtk2-devel libaio-devel
@@ -287,6 +293,7 @@ and xen.lowlevel.xc modules.
 %package libs
 Summary: Libraries for Xen tools
 Requires: xen-licenses
+Provides: xen-gvt-libs
 # toolstack <-> stubdomain API change
 Conflicts: xen-hvm-stubdom-linux < 1.1.0
 


### PR DESCRIPTION
This requires to add minimal support Intel GVT-g mediated passtrough
to Qubes OS. This patches based on Intel XenGT preview, XCP-NG
Project.