### PR TITLE
Use direct I/O for loop devices

### DIFF
--- a/patch-Linux-loop-use-direct-io.patch
+++ b/patch-Linux-loop-use-direct-io.patch
@@ -1,0 +1,11 @@
+--- xen-4.14.4/tools/hotplug/Linux/block	2022-01-31 04:44:39.000000000 -0500
++++ xen-4.14.4/tools/hotplug/Linux/block	2022-03-11 16:18:36.667000000 -0500
+@@ -330,7 +330,7 @@
+         else
+           roflag=''
+         fi
+-        do_or_die losetup $roflag "$loopdev" "$file"
++        do_or_die losetup --direct-io=on $roflag "$loopdev" "$file"
+         xenstore_write "$XENBUS_PATH/node" "$loopdev"
+         write_dev "$loopdev"
+         release_lock "block"

--- a/patch-xen-hotplug-external-store.patch
+++ b/patch-xen-hotplug-external-store.patch
@@ -25,7 +25,7 @@ Signed-off-by: Marek Marczykowski <marmarek@mimuw.edu.pl>
      FRONTEND_UUID=$(xenstore_read_default \
 @@ -305,6 +312,7 @@
          fi
-         do_or_die losetup $roflag "$loopdev" "$file"
+         do_or_die losetup --direct-io=on $roflag "$loopdev" "$file"
          xenstore_write "$XENBUS_PATH/node" "$loopdev"
 +        echo $loopdev > "$HOTPLUG_STORE-node"
          write_dev "$loopdev"

--- a/series-debian-vm.conf
+++ b/series-debian-vm.conf
@@ -17,6 +17,7 @@ patch-0002-common-remove-gzip-timestamp.patch
 patch-Define-build-dates-time-based-on-SOURCE_DATE_EPOCH.patch
 patch-docs-rename-DATE-to-PANDOC_REL_DATE-and-allow-to-spe.patch
 patch-docs-xen-headers-use-alphabetical-sorting-for-incont.patch
+patch-Linux-loop-use-direct-io.patch
 patch-Strip-build-path-directories-in-tools-xen-and-xen-ar.patch
 patch-x86-deal-with-gcc12-release-build-issues.patch
 patch-IOMMU-x86-work-around-bogus-gcc12-warning-in-hvm_gsi.patch

--- a/series-vm.conf
+++ b/series-vm.conf
@@ -1,4 +1,5 @@
 patch-xen-no-downloads.patch
+patch-Linux-loop-use-direct-io.patch
 patch-xen-hotplug-external-store.patch
 patch-xen-tools-qubes-vm.patch
 patch-libxc-fix-xc_gntshr_munmap-semantic.patch

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -193,6 +193,7 @@ Patch639: patch-libxl-add-pcidevs-to-stubdomain-earlier.patch
 Patch640: patch-xen-efi-align.patch
 Patch641: patch-0001-vchan-socket-proxy-add-reconnect-marker-support.patch
 Patch642: patch-0002-tools-libxl-enable-in-band-reconnect-marker-for-stub.patch
+Patch643: patch-Linux-loop-use-direct-io.patch
 
 # GCC8 fixes
 Patch714: patch-tools-kdd-mute-spurious-gcc-warning.patch


### PR DESCRIPTION
This is a huge performance improvement for two reasons:

1. It uses the filesystem’s asynchronous I/O support, rather than using
   synchronous I/O.
2. It bypasses the page cache, removing a redundant layer of caching and
   associated overhead.

I also took the opportunity to rip out some cruft related to old losetup
versions, which Qubes OS doesn't need to support anymore.

Fixes QubesOS/qubes-issues#7332.

Marking as draft because I have not tested this yet, and there is the possibility that it could break something.