### PR TITLE
modules: use https instead of old git:// protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "gui"]
 	path = gui-agent-xen-hvm-stubdom
-	url = git://github.com/QubesOS/qubes-gui-agent-xen-hvm-stubdom
+	url = https://github.com/QubesOS/qubes-gui-agent-xen-hvm-stubdom
 [submodule "gui-common"]
 	path = gui-common
-	url = git://github.com/QubesOS/qubes-gui-common
+	url = https://github.com/QubesOS/qubes-gui-common
 [submodule "core-vchan-xen"]
 	path = core-vchan-xen
-	url = git://github.com/QubesOS/qubes-core-vchan-xen
+	url = https://github.com/QubesOS/qubes-core-vchan-xen


### PR DESCRIPTION
I am getting the "connection reset by peer" erros when trying to fetch the git submodules:

```
-> Cloning qubes-vm-xen git repo...
Cloning into bare repository '/home/user/Repos/aur/qubes/qubes-vm-xen/qubes-vm-xen'...
remote: Enumerating objects: 7137, done.
remote: Counting objects: 100% (685/685), done.
remote: Compressing objects: 100% (388/388), done.
remote: Total 7137 (delta 311), reused 647 (delta 289), pack-reused 6452
Receiving objects: 100% (7137/7137), 6.10 MiB | 3.92 MiB/s, done.
Resolving deltas: 100% (3518/3518), done.
==> Validating source files with sha512sums...
    qubes-vm-xen ... Skipped
==> Verifying source file signatures with gpg...
    qubes-vm-xen git repo ... Passed
==> Extracting sources...
  -> Creating working copy of qubes-vm-xen git repo...
Cloning into 'qubes-vm-xen'...
done.
Switched to a new branch 'makepkg'
==> Removing existing $pkgdir/ directory...
==> Starting build()...
git submodule update --init --recursive
Submodule 'core-vchan-xen' (git://github.com/QubesOS/qubes-core-vchan-xen) registered for path 'core-vchan-xen'
Submodule 'gui' (git://github.com/QubesOS/qubes-gui-agent-xen-hvm-stubdom) registered for path 'gui-agent-xen-hvm-stubdom'
Submodule 'gui-common' (git://github.com/QubesOS/qubes-gui-common) registered for path 'gui-common'
Cloning into '/home/user/Repos/aur/qubes/qubes-vm-xen/src/qubes-vm-xen/core-vchan-xen'...
fatal: read error: Connection reset by peer
fatal: clone of 'git://github.com/QubesOS/qubes-core-vchan-xen' into submodule path '/home/user/Repos/aur/qubes/qubes-vm-xen/src/qubes-vm-xen/core-vchan-xen' failed
Failed to clone 'core-vchan-xen'. Retry scheduled
Cloning into '/home/user/Repos/aur/qubes/qubes-vm-xen/src/qubes-vm-xen/gui-agent-xen-hvm-stubdom'...
fatal: read error: Connection reset by peer
fatal: clone of 'git://github.com/QubesOS/qubes-gui-agent-xen-hvm-stubdom' into submodule path '/home/user/Repos/aur/qubes/qubes-vm-xen/src/qubes-vm-xen/gui-agent-xen-hvm-stubdom' failed
Failed to clone 'gui-agent-xen-hvm-stubdom'. Retry scheduled
Cloning into '/home/user/Repos/aur/qubes/qubes-vm-xen/src/qubes-vm-xen/gui-common'...
fatal: read error: Connection reset by peer
fatal: clone of 'git://github.com/QubesOS/qubes-gui-common' into submodule path '/home/user/Repos/aur/qubes/qubes-vm-xen/src/qubes-vm-xen/gui-common' failed
Failed to clone 'gui-common'. Retry scheduled
```

When I change the URLs to `https://` instead of `git://`, everything works as expected.

Ref.:
- https://github.blog/2021-09-01-improving-git-protocol-security-github/