### PR TITLE
Ease debugging gntdev driver failures

### DIFF
--- a/patch-x86-pv-Inject-GP-for-implicit-grant-unmaps.patch
+++ b/patch-x86-pv-Inject-GP-for-implicit-grant-unmaps.patch
@@ -1,0 +1,43 @@
+From f61c54967f4a5ea7e0c9fc3a4e966efa26481cb9 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 19 Jul 2022 21:37:43 +0100
+Subject: [PATCH] x86/pv: Inject #GP for implicit grant unmaps
+
+This is a debug behaviour to identify buggy kernels.  Crashing the domain is
+the most unhelpful thing to do, because it discards the relevant context.
+
+Instead, inject #GP[0] like other permission errors in x86.  In particular,
+this lets the kernel provide a backtrace which is more likely to be helpful to
+a developer.
+
+As a bugfix, this always injects #GP[0] to current, not l1e_owner.  It is not
+l1e_owner's fault if dom0 using superpowers triggers an implicit unmap.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Acked-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/mm.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/xen/arch/x86/mm.c b/xen/arch/x86/mm.c
+index 2c1c35151a85..22a4dfa83806 100644
+--- a/xen/arch/x86/mm.c
++++ b/xen/arch/x86/mm.c
+@@ -1229,10 +1229,10 @@ void put_page_from_l1e(l1_pgentry_t l1e, struct domain *l1e_owner)
+     if ( (l1e_get_flags(l1e) & _PAGE_GNTTAB) &&
+          !l1e_owner->is_shutting_down && !l1e_owner->is_dying )
+     {
+-        gdprintk(XENLOG_WARNING,
+-                 "Attempt to implicitly unmap a granted PTE %" PRIpte "\n",
+-                 l1e_get_intpte(l1e));
+-        domain_crash(l1e_owner);
++        gprintk(XENLOG_WARNING,
++                "Attempt to implicitly unmap %pd's grant PTE %" PRIpte "\n",
++                l1e_owner, l1e_get_intpte(l1e));
++        pv_inject_hw_exception(TRAP_gp_fault, 0);
+     }
+ #endif
+ 
+-- 
+2.35.3
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -108,6 +108,7 @@ Patch292: patch-0003-ns16550-add-Exar-PCIe-UART-cards-support.patch
 Patch293: patch-0001-x86-spec-ctrl-Skip-RSB-overwriting-when-safe-to-do-s.patch
 Patch294: patch-libxl-Fix-QEMU-cmdline-for-scsi-device.patch
 Patch295: patch-libxl-Replace-deprecated-QMP-command-by-query-cpus-f.patch
+Patch296: patch-x86-pv-Inject-GP-for-implicit-grant-unmaps.patch
 
 # Backport unified xen hypervisor patches from Xen 4.15
 Patch301: patch-unified-0001-x86-setup-Ignore-early-boot-parameters-like-no-real-.patch


### PR DESCRIPTION
Backport "x86/pv: Inject #GP for implicit grant unmaps" patch

QubesOS/qubes-issues#7631