### PR TITLE
EFI: preserve the System Resource Table for dom0

### DIFF
--- a/patch-0001-Validate-EFI-memory-descriptors.patch
+++ b/patch-0001-Validate-EFI-memory-descriptors.patch
@@ -1,0 +1,131 @@
+From 6936d67461716d8ba37ea8cc78743035c3e54e2d Mon Sep 17 00:00:00 2001
+Message-Id: <6936d67461716d8ba37ea8cc78743035c3e54e2d.1668832785.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+To: xen-devel@lists.xenproject.org
+Cc: Jan Beulich <jbeulich@suse.com>
+Cc: Andrew Cooper <andrew.cooper3@citrix.com>
+Cc: George Dunlap <george.dunlap@citrix.com>
+Cc: Julien Grall <julien@xen.org>
+Cc: Stefano Stabellini <sstabellini@kernel.org>
+Cc: Wei Liu <wl@xen.org>
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date: Fri, 18 Nov 2022 22:51:04 -0500
+Subject: [PATCH] Validate EFI memory descriptors
+
+It turns out that these can be invalid in various ways.  Based on code
+Ard Biesheuvel contributed for Linux.
+
+Co-developed-by: Ard Biesheuvel <ardb@kernel.org>
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Signed-off-by: Ard Biesheuvel <ardb@kernel.org>
+---
+ xen/common/efi/boot.c    | 11 +++++------
+ xen/common/efi/efi.h     | 14 ++++++++++++++
+ xen/common/efi/runtime.c | 13 ++++++-------
+ xen/include/xen/types.h  |  1 +
+ 4 files changed, 26 insertions(+), 13 deletions(-)
+
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index b3de1011ee58a67a82a94da050eb1343f4e37faa..dd0376fdf930c2fee35e79a2f2821361c5e15d33 100644
+--- a/xen/common/efi/boot.c
++++ b/xen/common/efi/boot.c
+@@ -591,15 +591,14 @@ static UINTN __initdata esrt = EFI_INVALID_TABLE_ADDR;
+ 
+ static size_t __init get_esrt_size(const EFI_MEMORY_DESCRIPTOR *desc)
+ {
+-    size_t available_len, len;
++    UINT64 available_len, len = efi_memory_descriptor_len(desc);
+     const UINTN physical_start = desc->PhysicalStart;
+     const EFI_SYSTEM_RESOURCE_TABLE *esrt_ptr;
+ 
+-    len = desc->NumberOfPages << EFI_PAGE_SHIFT;
+     if ( esrt == EFI_INVALID_TABLE_ADDR )
+-        return 0;
++        return 0; /* invalid ESRT */
+     if ( physical_start > esrt || esrt - physical_start >= len )
+-        return 0;
++        return 0; /* ESRT not in this memory region */
+     /*
+      * The specification requires EfiBootServicesData, but also accept
+      * EfiRuntimeServicesData (for compatibility with buggy firmware)
+@@ -609,10 +608,10 @@ static size_t __init get_esrt_size(const EFI_MEMORY_DESCRIPTOR *desc)
+     if ( (desc->Type != EfiRuntimeServicesData) &&
+          (desc->Type != EfiBootServicesData) &&
+          (desc->Type != EfiACPIReclaimMemory) )
+-        return 0;
++        return 0; /* memory region cannot contain ESRT */
+     available_len = len - (esrt - physical_start);
+     if ( available_len <= offsetof(EFI_SYSTEM_RESOURCE_TABLE, Entries) )
+-        return 0;
++        return 0; /* ESRT header does not fit in memory region */
+     available_len -= offsetof(EFI_SYSTEM_RESOURCE_TABLE, Entries);
+     esrt_ptr = (const EFI_SYSTEM_RESOURCE_TABLE *)esrt;
+     if ( (esrt_ptr->FwResourceVersion !=
+diff --git a/xen/common/efi/efi.h b/xen/common/efi/efi.h
+index c9aa65d506b14de69c90b6538c934747fcf0fb80..f4875138415c23eac42616131a738b7f8e33e56b 100644
+--- a/xen/common/efi/efi.h
++++ b/xen/common/efi/efi.h
+@@ -51,3 +51,17 @@ void free_ebmalloc_unused_mem(void);
+ 
+ const void *pe_find_section(const void *image_base, const size_t image_size,
+                             const CHAR16 *section_name, UINTN *size_out);
++
++static inline UINT64
++efi_memory_descriptor_len(const EFI_MEMORY_DESCRIPTOR *desc)
++{
++    uint64_t remaining_space = UINT64_MAX - desc->PhysicalStart;
++
++    if ( desc->PhysicalStart & (EFI_PAGE_SIZE - 1) )
++        return 0; /* misaligned start address */
++
++    if ( desc->NumberOfPages > (remaining_space >> EFI_PAGE_SHIFT) )
++        return 0; /* too big */
++
++    return desc->NumberOfPages << EFI_PAGE_SHIFT;
++}
+diff --git a/xen/common/efi/runtime.c b/xen/common/efi/runtime.c
+index 13b0975866e3a80c46a7e37788012a716a455b6a..b99de230a5464c46b0b6c19b073685b4e0298343 100644
+--- a/xen/common/efi/runtime.c
++++ b/xen/common/efi/runtime.c
+@@ -270,18 +270,17 @@ int efi_get_info(uint32_t idx, union xenpf_efi_info *info)
+         for ( i = 0; i < efi_memmap_size; i += efi_mdesc_size )
+         {
+             EFI_MEMORY_DESCRIPTOR *desc = efi_memmap + i;
+-            u64 len = desc->NumberOfPages << EFI_PAGE_SHIFT;
++            uint64_t size, len = efi_memory_descriptor_len(desc);
+ 
+             if ( info->mem.addr >= desc->PhysicalStart &&
+-                 info->mem.addr < desc->PhysicalStart + len )
++                 info->mem.addr - desc->PhysicalStart < len )
+             {
+                 info->mem.type = desc->Type;
+                 info->mem.attr = desc->Attribute;
+-                if ( info->mem.addr + info->mem.size < info->mem.addr ||
+-                     info->mem.addr + info->mem.size >
+-                     desc->PhysicalStart + len )
+-                    info->mem.size = desc->PhysicalStart + len -
+-                                     info->mem.addr;
++                size = desc->PhysicalStart + len - info->mem.addr;
++                if ( info->mem.size > size )
++                    info->mem.size = size;
++
+                 return 0;
+             }
+         }
+diff --git a/xen/include/xen/types.h b/xen/include/xen/types.h
+index 03f0fe612ed96118614505c39d0e33b946288d6c..255f5a3c91c6be3e8ba4584902563c11bee7f98d 100644
+--- a/xen/include/xen/types.h
++++ b/xen/include/xen/types.h
+@@ -25,6 +25,7 @@
+ #define UINT8_MAX       (255)
+ #define UINT16_MAX      (65535)
+ #define UINT32_MAX      (4294967295U)
++#define UINT64_MAX      (0xFFFFFFFFFFFFFFFFULL)
+ 
+ #define INT_MAX         ((int)(~0U>>1))
+ #define INT_MIN         (-INT_MAX - 1)
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab
+

--- a/patch-EFI-preserve-the-System-Resource-Table-for-dom0.patch
+++ b/patch-EFI-preserve-the-System-Resource-Table-for-dom0.patch
@@ -1,0 +1,224 @@
+From 49c3c3b032ec4652ea6c9fe0ac688ba063b68275 Mon Sep 17 00:00:00 2001
+Message-Id: <49c3c3b032ec4652ea6c9fe0ac688ba063b68275.1660882461.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 12 Jul 2022 08:39:19 +0200
+Subject: [PATCH] EFI: preserve the System Resource Table for dom0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The EFI System Resource Table (ESRT) is necessary for fwupd to identify
+firmware updates to install.  According to the UEFI specification §23.4,
+the ESRT shall be stored in memory of type EfiBootServicesData.  However,
+memory of type EfiBootServicesData is considered general-purpose memory
+by Xen, so the ESRT needs to be moved somewhere where Xen will not
+overwrite it.  Copy the ESRT to memory of type EfiACPIReclaimMemory,
+which Xen will not reuse.  dom0 can use the ESRT if (and only if) it is
+in memory of type EfiRuntimeServicesData or EfiACPIReclaimMemory.
+
+Earlier versions of this patch reserved the memory in which the ESRT was
+located.  This created awkward alignment problems, and required either
+splitting the E820 table or wasting memory.  It also would have required
+a new platform op for dom0 to use to indicate if the ESRT is reserved.
+By copying the ESRT into EfiACPIReclaimMemory memory, the E820 table
+does not need to be modified, and dom0 can just check the type of the
+memory region containing the ESRT.  The copy is only done if the ESRT is
+not already in EfiRuntimeServicesData or EfiACPIReclaimMemory memory,
+avoiding memory leaks on repeated kexec.
+
+See https://lore.kernel.org/xen-devel/20200818184018.GN1679@mail-itl/T/
+for details.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Tested-by: Luca Fancellu <luca.fancellu@arm.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/common/efi/boot.c | 127 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 127 insertions(+)
+
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index 5a520bf21d3a25e87cf38310a066da004a243006..79b31981ae532e541811582ac1e773db0eb864eb 100644
+--- a/xen/common/efi/boot.c
++++ b/xen/common/efi/boot.c
+@@ -38,6 +38,26 @@
+   { 0x605dab50, 0xe046, 0x4300, {0xab, 0xb6, 0x3d, 0xd8, 0x10, 0xdd, 0x8b, 0x23} }
+ #define APPLE_PROPERTIES_PROTOCOL_GUID \
+   { 0x91bd12fe, 0xf6c3, 0x44fb, { 0xa5, 0xb7, 0x51, 0x22, 0xab, 0x30, 0x3a, 0xe0} }
++#define EFI_SYSTEM_RESOURCE_TABLE_GUID    \
++  { 0xb122a263, 0x3661, 0x4f68, {0x99, 0x29, 0x78, 0xf8, 0xb0, 0xd6, 0x21, 0x80} }
++#define EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION 1
++
++typedef struct {
++    EFI_GUID FwClass;
++    UINT32 FwType;
++    UINT32 FwVersion;
++    UINT32 LowestSupportedFwVersion;
++    UINT32 CapsuleFlags;
++    UINT32 LastAttemptVersion;
++    UINT32 LastAttemptStatus;
++} EFI_SYSTEM_RESOURCE_ENTRY;
++
++typedef struct {
++    UINT32 FwResourceCount;
++    UINT32 FwResourceCountMax;
++    UINT64 FwResourceVersion;
++    EFI_SYSTEM_RESOURCE_ENTRY Entries[];
++} EFI_SYSTEM_RESOURCE_TABLE;
+ 
+ typedef EFI_STATUS
+ (/* _not_ EFIAPI */ *EFI_SHIM_LOCK_VERIFY) (
+@@ -750,6 +770,43 @@ static char *__init get_value(const struct file *cfg, const char *section,
+     return NULL;
+ }
+ 
++static UINTN __initdata esrt = EFI_INVALID_TABLE_ADDR;
++
++static size_t __init get_esrt_size(const EFI_MEMORY_DESCRIPTOR *desc)
++{
++    size_t available_len, len;
++    const UINTN physical_start = desc->PhysicalStart;
++    const EFI_SYSTEM_RESOURCE_TABLE *esrt_ptr;
++
++    len = desc->NumberOfPages << EFI_PAGE_SHIFT;
++    if ( esrt == EFI_INVALID_TABLE_ADDR )
++        return 0;
++    if ( physical_start > esrt || esrt - physical_start >= len )
++        return 0;
++    /*
++     * The specification requires EfiBootServicesData, but accept
++     * EfiRuntimeServicesData (for compatibility) and EfiACPIReclaimMemory
++     * (a more logical choice).
++     */
++    if ( (desc->Type != EfiRuntimeServicesData) &&
++         (desc->Type != EfiBootServicesData) &&
++         (desc->Type != EfiACPIReclaimMemory) )
++        return 0;
++    available_len = len - (esrt - physical_start);
++    if ( available_len <= offsetof(EFI_SYSTEM_RESOURCE_TABLE, Entries) )
++        return 0;
++    available_len -= offsetof(EFI_SYSTEM_RESOURCE_TABLE, Entries);
++    esrt_ptr = (const EFI_SYSTEM_RESOURCE_TABLE *)esrt;
++    if ( (esrt_ptr->FwResourceVersion !=
++          EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION) ||
++         !esrt_ptr->FwResourceCount )
++        return 0;
++    if ( esrt_ptr->FwResourceCount > available_len / sizeof(esrt_ptr->Entries[0]) )
++        return 0;
++
++    return esrt_ptr->FwResourceCount * sizeof(esrt_ptr->Entries[0]);
++}
++
+ static void __init efi_init(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+ {
+     efi_ih = ImageHandle;
+@@ -904,6 +961,8 @@ static UINTN __init efi_find_gop_mode(EFI_GRAPHICS_OUTPUT_PROTOCOL *gop,
+     return gop_mode;
+ }
+ 
++static EFI_GUID __initdata esrt_guid = EFI_SYSTEM_RESOURCE_TABLE_GUID;
++
+ static void __init efi_tables(void)
+ {
+     unsigned int i;
+@@ -929,6 +986,8 @@ static void __init efi_tables(void)
+ 	       efi.smbios = (long)efi_ct[i].VendorTable;
+         if ( match_guid(&smbios3_guid, &efi_ct[i].VendorGuid) )
+ 	       efi.smbios3 = (long)efi_ct[i].VendorTable;
++        if ( match_guid(&esrt_guid, &efi_ct[i].VendorGuid) )
++            esrt = (UINTN)efi_ct[i].VendorTable;
+     }
+ 
+ #ifndef CONFIG_ARM /* TODO - disabled until implemented on ARM */
+@@ -1114,6 +1175,79 @@ static void __init efi_set_gop_mode(EFI_GRAPHICS_OUTPUT_PROTOCOL *gop, UINTN gop
+ #define INVALID_VIRTUAL_ADDRESS (0xBAAADUL << \
+                                  (EFI_PAGE_SHIFT + BITS_PER_LONG - 32))
+ 
++static void __init efi_relocate_esrt(EFI_SYSTEM_TABLE *SystemTable)
++{
++    EFI_STATUS status;
++    UINTN info_size = 0, map_key, mdesc_size;
++    void *memory_map = NULL;
++    UINT32 ver;
++    unsigned int i;
++    bool esrt_relocated = false;
++
++    for ( ; ; )
++    {
++        status = efi_bs->GetMemoryMap(&info_size, memory_map, &map_key,
++                                      &mdesc_size, &ver);
++        if ( status == EFI_SUCCESS && memory_map != NULL )
++            break;
++        if ( status == EFI_BUFFER_TOO_SMALL || memory_map == NULL )
++        {
++            info_size += 8 * mdesc_size;
++            if ( memory_map != NULL )
++                efi_bs->FreePool(memory_map);
++            memory_map = NULL;
++            status = efi_bs->AllocatePool(EfiLoaderData, info_size, &memory_map);
++            if ( status == EFI_SUCCESS )
++                continue;
++            PrintErr(L"Cannot allocate memory to relocate ESRT\r\n");
++        }
++        else
++            PrintErr(L"Cannot obtain memory map to relocate ESRT\r\n");
++        return;
++    }
++
++    /* Try to obtain the ESRT.  Errors are not fatal. */
++    for ( i = 0; i < info_size; i += mdesc_size )
++    {
++        /*
++         * ESRT needs to be moved to memory of type EfiRuntimeServicesData
++         * so that the memory it is in will not be used for other purposes.
++         */
++        void *new_esrt = NULL;
++        size_t esrt_size = get_esrt_size(memory_map + i);
++
++        if ( !esrt_size )
++            continue;
++        if ( ((EFI_MEMORY_DESCRIPTOR *)(memory_map + i))->Type ==
++             EfiRuntimeServicesData )
++            break; /* ESRT already safe from reuse */
++        status = efi_bs->AllocatePool(EfiRuntimeServicesData, esrt_size,
++                                      &new_esrt);
++        if ( status == EFI_SUCCESS && new_esrt )
++        {
++            memcpy(new_esrt, (void *)esrt, esrt_size);
++            status = efi_bs->InstallConfigurationTable(&esrt_guid, new_esrt);
++            if ( status != EFI_SUCCESS )
++            {
++                PrintErr(L"Cannot install new ESRT\r\n");
++                efi_bs->FreePool(new_esrt);
++            }
++            else
++            {
++                esrt_relocated = true;
++            }
++        }
++        else
++            PrintErr(L"Cannot allocate memory for ESRT\r\n");
++        break;
++    }
++
++    if (!esrt_relocated)
++        PrintErr(L"Could not relocate ESRT\r\n");
++
++    efi_bs->FreePool(memory_map);
++}
++
+ static void __init efi_exit_boot(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable, bool exit_boot_services)
+ {
+     EFI_STATUS status;
+@@ -1468,6 +1602,8 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable, bool exit_boot_services)
+     if ( gop )
+         efi_set_gop_mode(gop, gop_mode);
+ 
++    efi_relocate_esrt(SystemTable);
++
+     efi_exit_boot(ImageHandle, SystemTable, exit_boot_services);
+ 
+     efi_arch_post_exit_boot(); /* Doesn't return. */
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -205,6 +205,7 @@ Patch647: patch-0004-libxl-Fix-race-condition-in-domain-suspension.patch
 Patch648: patch-0005-libxl-Add-additional-domain-suspend-resume-logs.patch
 Patch649: patch-pvcontrol-0001-libxl-workaround-for-Windows-PV-drivers-removing-con.patch
 Patch650: patch-pvcontrol-0002-libxl-check-control-feature-before-issuing-pvcontrol.patch
+Patch651: patch-0001-Validate-EFI-memory-descriptors.patch
 
 # GCC8 fixes
 Patch714: patch-tools-kdd-mute-spurious-gcc-warning.patch

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -148,6 +148,7 @@ Patch309: patch-unified-0009-EFI-Arm64-don-t-clobber-DTB-pointer.patch
 Patch310: patch-unified-0010-EFI-further-need_to_free-adjustments.patch
 
 Patch320: patch-libxl-resume.patch
+Patch321: patch-EFI-preserve-the-System-Resource-Table-for-dom0.patch
 
 # Security fixes
 Patch500: patch-xsa401-4.16-1.patch


### PR DESCRIPTION
The EFI System Resource Table (ESRT) is necessary for fwupd to identify
firmware updates to install.  According to the UEFI specification §23.4,
the ESRT shall be stored in memory of type EfiBootServicesData.  However,
memory of type EfiBootServicesData is considered general-purpose memory
by Xen, so the ESRT needs to be moved somewhere where Xen will not
overwrite it.  Copy the ESRT to memory of type EfiRuntimeServicesData,
which Xen will not reuse.  dom0 can use the ESRT if (and only if) it is
in memory of type EfiRuntimeServicesData.

Earlier versions of this patch reserved the memory in which the ESRT was
located.  This created awkward alignment problems, and required either
splitting the E820 table or wasting memory.  It also would have required
a new platform op for dom0 to use to indicate if the ESRT is reserved.
By copying the ESRT into EfiRuntimeServicesData memory, the E820 table
does not need to be modified, and dom0 can just check the type of the
memory region containing the ESRT.  The copy is only done if the ESRT is
not already in EfiRuntimeServicesData memory, avoiding memory leaks on
repeated kexec.

See https://lore.kernel.org/xen-devel/20200818184018.GN1679@mail-itl/T/
for details.