### PR TITLE
Fix reproducibility

### DIFF
--- a/0626-docs-do-not-install-.deps-files.patch
+++ b/0626-docs-do-not-install-.deps-files.patch
@@ -1,0 +1,32 @@
+From 7fd402ddf2b92c39fa5c25e7049bb41a5c8ec53e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Sat, 10 Dec 2022 03:36:11 +0100
+Subject: [PATCH] docs: do not install .deps files
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It isn't really part of the documentation. Furthermore, entries there
+are in not determined order, which breaks build reproducibility.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ docs/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/docs/Makefile b/docs/Makefile
+index 8de1efb6f5bc..966a104490ac 100644
+--- a/docs/Makefile
++++ b/docs/Makefile
+@@ -178,6 +178,7 @@ $(foreach i,$(MAN_SECTIONS),$(eval $(call GENERATE_MANPAGE_RULES,$(i))))
+ install-html: html txt figs
+ 	$(INSTALL_DIR) $(DESTDIR)$(docdir)
+ 	[ ! -d html ] || cp -R html $(DESTDIR)$(docdir)
++	rm -f $(DESTDIR)$(docdir)/html/hypercall/*/.deps
+ 
+ .PHONY: install
+ install: install-man-pages install-html
+-- 
+2.37.3
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -122,6 +122,7 @@ Patch0622: 0622-libxl-check-control-feature-before-issuing-pvcontrol.patch
 Patch0623: 0623-tools-kdd-mute-spurious-gcc-warning.patch
 Patch0624: 0624-libxl-do-not-start-qemu-in-dom0-just-for-extra-conso.patch
 Patch0625: 0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch
+Patch0626: 0626-docs-do-not-install-.deps-files.patch
 
 # Qubes specific patches
 Patch1000: 1000-Do-not-access-network-during-the-build.patch


### PR DESCRIPTION
Fix reproducibility of the package. This PR includes one patch, but that isn't enough: at least `iasl` produces non-reproducible output (embeds build timestamp).