### PR TITLE
Backport PAT changes from Xen git master

### DIFF
--- a/0301-x86-mm-shadow-avoid-assuming-a-specific-Xen-PAT.patch
+++ b/0301-x86-mm-shadow-avoid-assuming-a-specific-Xen-PAT.patch
@@ -1,0 +1,43 @@
+From 53ba5e1b48a538c366e4621634b493f4585bcac0 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 6 Dec 2022 13:54:33 +0100
+Subject: [PATCH 1/9] x86/mm/shadow: avoid assuming a specific Xen PAT
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+This makes the code easier to understand and more robust if Xen's PAT
+ever changes.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+---
+ xen/arch/x86/mm/shadow/multi.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xen/arch/x86/mm/shadow/multi.c b/xen/arch/x86/mm/shadow/multi.c
+index 2370b3060285fee895f335f2a82d3d22ca5d31ed..4e94fec3d50cde0e5a26ecb62ff4d00dd00f759d 100644
+--- a/xen/arch/x86/mm/shadow/multi.c
++++ b/xen/arch/x86/mm/shadow/multi.c
+@@ -629,8 +629,8 @@ _sh_propagate(struct vcpu *v,
+     else if ( p2mt == p2m_mmio_direct &&
+               rangeset_contains_singleton(mmio_ro_ranges, mfn_x(target_mfn)) )
+     {
+-        sflags &= ~(_PAGE_RW | _PAGE_PAT);
+-        sflags |= _PAGE_PCD | _PAGE_PWT;
++        sflags &= ~(_PAGE_RW | PAGE_CACHE_ATTRS);
++        sflags |= _PAGE_UC;
+     }
+ 
+     // protect guest page tables
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/0302-x86-mm-shadow-do-not-open-code-PAGE_CACHE_ATTRS.patch
+++ b/0302-x86-mm-shadow-do-not-open-code-PAGE_CACHE_ATTRS.patch
@@ -1,0 +1,49 @@
+From a6da84524ceaf24ff997d03407b93f60c12857f3 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 6 Dec 2022 13:55:07 +0100
+Subject: [PATCH 2/9] x86/mm/shadow: do not open-code PAGE_CACHE_ATTRS
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+This makes the code easier to understand.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Acked-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/mm/shadow/multi.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xen/arch/x86/mm/shadow/multi.c b/xen/arch/x86/mm/shadow/multi.c
+index 4e94fec3d50cde0e5a26ecb62ff4d00dd00f759d..6bb564b0145285afc93b72a60b7797fcfe8696dc 100644
+--- a/xen/arch/x86/mm/shadow/multi.c
++++ b/xen/arch/x86/mm/shadow/multi.c
+@@ -535,7 +535,7 @@ _sh_propagate(struct vcpu *v,
+     if ( guest_nx_enabled(v) )
+         pass_thru_flags |= _PAGE_NX_BIT;
+     if ( level == 1 && !shadow_mode_refcounts(d) && mmio_mfn )
+-        pass_thru_flags |= _PAGE_PAT | _PAGE_PCD | _PAGE_PWT;
++        pass_thru_flags |= PAGE_CACHE_ATTRS;
+     sflags = gflags & pass_thru_flags;
+ 
+     /*
+@@ -548,7 +548,7 @@ _sh_propagate(struct vcpu *v,
+     {
+         int type;
+ 
+-        ASSERT(!(sflags & (_PAGE_PAT | _PAGE_PCD | _PAGE_PWT)));
++        ASSERT(!(sflags & PAGE_CACHE_ATTRS));
+ 
+         /* compute the PAT index for shadow page entry when VT-d is enabled
+          * and device assigned.
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/0303-p2m-pt-Avoid-hard-coding-Xen-s-PAT.patch
+++ b/0303-p2m-pt-Avoid-hard-coding-Xen-s-PAT.patch
@@ -1,0 +1,50 @@
+From 1ca8af08dfa46a8b3c376e0bd1b74ccde579f48d Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Thu, 15 Dec 2022 17:03:45 +0100
+Subject: [PATCH 3/9] p2m-pt: Avoid hard-coding Xen's PAT
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+This makes the code much easier to understand.  No functional change
+intended.  As per Andrew Cooper, the existing logic is questionable, but
+this does not make it any worse.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Acked-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/mm/p2m-pt.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/xen/arch/x86/mm/p2m-pt.c b/xen/arch/x86/mm/p2m-pt.c
+index eaba2b0fb4e6830f52b7d112fba8175dfe6d2770..cd1af33b6772ab1016e8d4c3284a6bc5d282869d 100644
+--- a/xen/arch/x86/mm/p2m-pt.c
++++ b/xen/arch/x86/mm/p2m-pt.c
+@@ -99,13 +99,13 @@ static unsigned long p2m_type_to_flags(const struct p2m_domain *p2m,
+         return flags | P2M_BASE_FLAGS | _PAGE_RW | _PAGE_NX_BIT;
+     case p2m_mmio_direct:
+         if ( !rangeset_contains_singleton(mmio_ro_ranges, mfn_x(mfn)) )
+-            flags |= _PAGE_RW;
++            flags |= _PAGE_RW | _PAGE_UCM;
+         else
+         {
+-            flags |= _PAGE_PWT;
++            flags |= _PAGE_UC;
+             ASSERT(!level);
+         }
+-        return flags | P2M_BASE_FLAGS | _PAGE_PCD;
++        return flags | P2M_BASE_FLAGS;
+     }
+ }
+ 
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/0304-efi-Avoid-hard-coding-the-various-PAT-constants.patch
+++ b/0304-efi-Avoid-hard-coding-the-various-PAT-constants.patch
@@ -1,0 +1,62 @@
+From 32b61bcafccc1f12b7e98d2d2e3cef763ac1fb60 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Thu, 15 Dec 2022 17:04:40 +0100
+Subject: [PATCH 4/9] efi: Avoid hard-coding the various PAT constants
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+This makes the code much easier to understand, and avoids problems if
+Xen's PAT ever changes in the future.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/common/efi/boot.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index d521b47bc6d9513ca6e65c3170abb94881a71910..e1248d63e7f99d598a6b1df04e34ed34ed0b6910 100644
+--- a/xen/common/efi/boot.c
++++ b/xen/common/efi/boot.c
+@@ -1748,23 +1748,23 @@ void __init efi_init_memory(void)
+         emfn = PFN_UP(desc->PhysicalStart + len);
+ 
+         if ( desc->Attribute & EFI_MEMORY_WB )
+-            /* nothing */;
++            prot |= _PAGE_WB;
+         else if ( desc->Attribute & EFI_MEMORY_WT )
+-            prot |= _PAGE_PWT | MAP_SMALL_PAGES;
++            prot |= _PAGE_WT | MAP_SMALL_PAGES;
+         else if ( desc->Attribute & EFI_MEMORY_WC )
+-            prot |= _PAGE_PAT | MAP_SMALL_PAGES;
++            prot |= _PAGE_WC | MAP_SMALL_PAGES;
+         else if ( desc->Attribute & (EFI_MEMORY_UC | EFI_MEMORY_UCE) )
+-            prot |= _PAGE_PWT | _PAGE_PCD | MAP_SMALL_PAGES;
++            prot |= _PAGE_UC | MAP_SMALL_PAGES;
+         else if ( efi_bs_revision >= EFI_REVISION(2, 5) &&
+                   (desc->Attribute & EFI_MEMORY_WP) )
+-            prot |= _PAGE_PAT | _PAGE_PWT | MAP_SMALL_PAGES;
++            prot |= _PAGE_WP | MAP_SMALL_PAGES;
+         else
+         {
+             printk(XENLOG_ERR "Unknown cachability for MFNs %#lx-%#lx%s\n",
+                    smfn, emfn - 1, efi_map_uc ? ", assuming UC" : "");
+             if ( !efi_map_uc )
+                 continue;
+-            prot |= _PAGE_PWT | _PAGE_PCD | MAP_SMALL_PAGES;
++            prot |= _PAGE_UC | MAP_SMALL_PAGES;
+         }
+ 
+         if ( desc->Attribute & (efi_bs_revision < EFI_REVISION(2, 5)
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/0305-x86-Add-memory-type-constants.patch
+++ b/0305-x86-Add-memory-type-constants.patch
@@ -1,0 +1,52 @@
+From 4714ae256f8cf75af2631eadc6d275e04f4d5d17 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 20 Dec 2022 16:49:16 +0100
+Subject: [PATCH 5/9] x86: Add memory type constants
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+These are not currently used, so there is no functional change.  Future
+patches will use these constants.
+
+Suggested-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Acked-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/include/asm/x86-defns.h | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/xen/arch/x86/include/asm/x86-defns.h b/xen/arch/x86/include/asm/x86-defns.h
+index 28628807cb9897cf6fa8e266f71f5f220813984d..42b5f382d438d21ac97b6438e8c810c7b964cf6d 100644
+--- a/xen/arch/x86/include/asm/x86-defns.h
++++ b/xen/arch/x86/include/asm/x86-defns.h
+@@ -153,4 +153,15 @@
+      (1u << X86_EXC_AC) | (1u << X86_EXC_CP) |                      \
+      (1u << X86_EXC_VC) | (1u << X86_EXC_SX))
+ 
++/* Memory types */
++#define X86_MT_UC     0x00 /* uncachable */
++#define X86_MT_WC     0x01 /* write-combined */
++#define X86_MT_RSVD_2 0x02 /* reserved */
++#define X86_MT_RSVD_3 0x03 /* reserved */
++#define X86_MT_WT     0x04 /* write-through */
++#define X86_MT_WP     0x05 /* write-protect */
++#define X86_MT_WB     0x06 /* write-back */
++#define X86_MT_UCM    0x07 /* UC- */
++#define X86_NUM_MT    0x08
++
+ #endif	/* __XEN_X86_DEFNS_H__ */
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/0306-x86-Replace-PAT_-with-X86_MT_.patch
+++ b/0306-x86-Replace-PAT_-with-X86_MT_.patch
@@ -1,0 +1,282 @@
+From 60b8f9a73987e22ab652ac0d4bdd2db81d1dc33a Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 20 Dec 2022 16:49:35 +0100
+Subject: [PATCH 6/9] x86: Replace PAT_* with X86_MT_*
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+This allows eliminating the former.
+
+Suggested-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/hvm/hvm.c          | 12 ++++----
+ xen/arch/x86/hvm/mtrr.c         | 52 ++++++++++++++++-----------------
+ xen/arch/x86/hvm/vmx/vmx.c      | 16 +++++-----
+ xen/arch/x86/include/asm/mtrr.h | 12 +-------
+ xen/arch/x86/mm/p2m-ept.c       |  4 +--
+ xen/arch/x86/mm/shadow/multi.c  |  4 +--
+ 6 files changed, 45 insertions(+), 55 deletions(-)
+
+diff --git a/xen/arch/x86/hvm/hvm.c b/xen/arch/x86/hvm/hvm.c
+index ae4368ec4b338cf8c6cb14d383f612c91c98e800..00b3fa56e25e2934e2870e11fd19b120daff2715 100644
+--- a/xen/arch/x86/hvm/hvm.c
++++ b/xen/arch/x86/hvm/hvm.c
+@@ -307,12 +307,12 @@ int hvm_set_guest_pat(struct vcpu *v, uint64_t guest_pat)
+     for ( i = 0, tmp = guest_pat; i < 8; i++, tmp >>= 8 )
+         switch ( tmp & 0xff )
+         {
+-        case PAT_TYPE_UC_MINUS:
+-        case PAT_TYPE_UNCACHABLE:
+-        case PAT_TYPE_WRBACK:
+-        case PAT_TYPE_WRCOMB:
+-        case PAT_TYPE_WRPROT:
+-        case PAT_TYPE_WRTHROUGH:
++        case X86_MT_UCM:
++        case X86_MT_UC:
++        case X86_MT_WB:
++        case X86_MT_WC:
++        case X86_MT_WP:
++        case X86_MT_WT:
+             break;
+         default:
+             return 0;
+diff --git a/xen/arch/x86/hvm/mtrr.c b/xen/arch/x86/hvm/mtrr.c
+index 4d2aa6def86de45aeeaade7a1a7815c5ef2b3d7a..242623f3c239ee18a44f882ecb3910a00c615825 100644
+--- a/xen/arch/x86/hvm/mtrr.c
++++ b/xen/arch/x86/hvm/mtrr.c
+@@ -37,7 +37,7 @@ static const uint8_t pat_entry_2_pte_flags[8] = {
+     _PAGE_PAT | _PAGE_PCD, _PAGE_PAT | _PAGE_PCD | _PAGE_PWT };
+ 
+ /* Effective mm type lookup table, according to MTRR and PAT. */
+-static const uint8_t mm_type_tbl[MTRR_NUM_TYPES][PAT_TYPE_NUMS] = {
++static const uint8_t mm_type_tbl[MTRR_NUM_TYPES][X86_NUM_MT] = {
+ #define RS MEMORY_NUM_TYPES
+ #define UC MTRR_TYPE_UNCACHABLE
+ #define WB MTRR_TYPE_WRBACK
+@@ -72,8 +72,8 @@ static uint8_t __read_mostly mtrr_epat_tbl[MTRR_NUM_TYPES][MEMORY_NUM_TYPES] =
+     };
+ 
+ /* Lookup table for PAT entry of a given PAT value in host PAT. */
+-static uint8_t __read_mostly pat_entry_tbl[PAT_TYPE_NUMS] =
+-    { [0 ... PAT_TYPE_NUMS-1] = INVALID_MEM_TYPE };
++static uint8_t __read_mostly pat_entry_tbl[X86_NUM_MT] =
++    { [0 ... X86_NUM_MT - 1] = INVALID_MEM_TYPE };
+ 
+ static int __init cf_check hvm_mtrr_pat_init(void)
+ {
+@@ -81,7 +81,7 @@ static int __init cf_check hvm_mtrr_pat_init(void)
+ 
+     for ( i = 0; i < MTRR_NUM_TYPES; i++ )
+     {
+-        for ( j = 0; j < PAT_TYPE_NUMS; j++ )
++        for ( j = 0; j < X86_NUM_MT; j++ )
+         {
+             unsigned int tmp = mm_type_tbl[i][j];
+ 
+@@ -90,9 +90,9 @@ static int __init cf_check hvm_mtrr_pat_init(void)
+         }
+     }
+ 
+-    for ( i = 0; i < PAT_TYPE_NUMS; i++ )
++    for ( i = 0; i < X86_NUM_MT; i++ )
+     {
+-        for ( j = 0; j < PAT_TYPE_NUMS; j++ )
++        for ( j = 0; j < X86_NUM_MT; j++ )
+         {
+             if ( pat_cr_2_paf(XEN_MSR_PAT, j) == i )
+             {
+@@ -115,7 +115,7 @@ uint8_t pat_type_2_pte_flags(uint8_t pat_type)
+      * given pat_type. If host PAT covers all the PAT types, it can't happen.
+      */
+     if ( unlikely(pat_entry == INVALID_MEM_TYPE) )
+-        pat_entry = pat_entry_tbl[PAT_TYPE_UNCACHABLE];
++        pat_entry = pat_entry_tbl[X86_MT_UC];
+ 
+     return pat_entry_2_pte_flags[pat_entry];
+ }
+@@ -145,14 +145,14 @@ int hvm_vcpu_cacheattr_init(struct vcpu *v)
+     m->mtrr_cap = (1u << 10) | (1u << 8) | num_var_ranges;
+ 
+     v->arch.hvm.pat_cr =
+-        ((uint64_t)PAT_TYPE_WRBACK) |               /* PAT0: WB */
+-        ((uint64_t)PAT_TYPE_WRTHROUGH << 8) |       /* PAT1: WT */
+-        ((uint64_t)PAT_TYPE_UC_MINUS << 16) |       /* PAT2: UC- */
+-        ((uint64_t)PAT_TYPE_UNCACHABLE << 24) |     /* PAT3: UC */
+-        ((uint64_t)PAT_TYPE_WRBACK << 32) |         /* PAT4: WB */
+-        ((uint64_t)PAT_TYPE_WRTHROUGH << 40) |      /* PAT5: WT */
+-        ((uint64_t)PAT_TYPE_UC_MINUS << 48) |       /* PAT6: UC- */
+-        ((uint64_t)PAT_TYPE_UNCACHABLE << 56);      /* PAT7: UC */
++        ((uint64_t)X86_MT_WB) |           /* PAT0: WB */
++        ((uint64_t)X86_MT_WT << 8) |      /* PAT1: WT */
++        ((uint64_t)X86_MT_UCM << 16) |    /* PAT2: UC- */
++        ((uint64_t)X86_MT_UC << 24) |     /* PAT3: UC */
++        ((uint64_t)X86_MT_WB << 32) |     /* PAT4: WB */
++        ((uint64_t)X86_MT_WT << 40) |     /* PAT5: WT */
++        ((uint64_t)X86_MT_UCM << 48) |    /* PAT6: UC- */
++        ((uint64_t)X86_MT_UC << 56);      /* PAT7: UC */
+ 
+     if ( is_hardware_domain(v->domain) )
+     {
+@@ -356,7 +356,7 @@ uint32_t get_pat_flags(struct vcpu *v,
+      */
+     pat_entry_value = mtrr_epat_tbl[shadow_mtrr_type][guest_eff_mm_type];
+     /* If conflit occurs(e.g host MTRR is UC, guest memory type is
+-     * WB),set UC as effective memory. Here, returning PAT_TYPE_UNCACHABLE will
++     * WB), set UC as effective memory. Here, returning X86_MT_UC will
+      * always set effective memory as UC.
+      */
+     if ( pat_entry_value == INVALID_MEM_TYPE )
+@@ -371,7 +371,7 @@ uint32_t get_pat_flags(struct vcpu *v,
+                     "because the host mtrr type is:%d\n",
+                     gl1e_flags, (uint64_t)gpaddr, guest_eff_mm_type,
+                     shadow_mtrr_type);
+-        pat_entry_value = PAT_TYPE_UNCACHABLE;
++        pat_entry_value = X86_MT_UC;
+     }
+     /* 4. Get the pte flags */
+     return pat_type_2_pte_flags(pat_entry_value);
+@@ -620,13 +620,13 @@ int hvm_set_mem_pinned_cacheattr(struct domain *d, uint64_t gfn_start,
+                 p2m_memory_type_changed(d);
+                 switch ( type )
+                 {
+-                case PAT_TYPE_UC_MINUS:
++                case X86_MT_UCM:
+                     /*
+                      * For EPT we can also avoid the flush in this case;
+                      * see epte_get_entry_emt().
+                      */
+                     if ( hap_enabled(d) && cpu_has_vmx )
+-                case PAT_TYPE_UNCACHABLE:
++                case X86_MT_UC:
+                         break;
+                     /* fall through */
+                 default:
+@@ -638,12 +638,12 @@ int hvm_set_mem_pinned_cacheattr(struct domain *d, uint64_t gfn_start,
+         rcu_read_unlock(&pinned_cacheattr_rcu_lock);
+         return -ENOENT;
+ 
+-    case PAT_TYPE_UC_MINUS:
+-    case PAT_TYPE_UNCACHABLE:
+-    case PAT_TYPE_WRBACK:
+-    case PAT_TYPE_WRCOMB:
+-    case PAT_TYPE_WRPROT:
+-    case PAT_TYPE_WRTHROUGH:
++    case X86_MT_UCM:
++    case X86_MT_UC:
++    case X86_MT_WB:
++    case X86_MT_WC:
++    case X86_MT_WP:
++    case X86_MT_WT:
+         break;
+ 
+     default:
+@@ -681,7 +681,7 @@ int hvm_set_mem_pinned_cacheattr(struct domain *d, uint64_t gfn_start,
+ 
+     list_add_rcu(&range->list, &d->arch.hvm.pinned_cacheattr_ranges);
+     p2m_memory_type_changed(d);
+-    if ( type != PAT_TYPE_WRBACK )
++    if ( type != X86_MT_WB )
+         flush_all(FLUSH_CACHE);
+ 
+     return 0;
+diff --git a/xen/arch/x86/hvm/vmx/vmx.c b/xen/arch/x86/hvm/vmx/vmx.c
+index 7c81b80710f99e08fe8291d3e413c449322b777d..b543c3983d77ae807e8bd97330691a79d8d39bae 100644
+--- a/xen/arch/x86/hvm/vmx/vmx.c
++++ b/xen/arch/x86/hvm/vmx/vmx.c
+@@ -1231,14 +1231,14 @@ static void cf_check vmx_handle_cd(struct vcpu *v, unsigned long value)
+              * memory type are all UC.
+              */
+             u64 uc_pat =
+-                ((uint64_t)PAT_TYPE_UNCACHABLE)       |       /* PAT0 */
+-                ((uint64_t)PAT_TYPE_UNCACHABLE << 8)  |       /* PAT1 */
+-                ((uint64_t)PAT_TYPE_UNCACHABLE << 16) |       /* PAT2 */
+-                ((uint64_t)PAT_TYPE_UNCACHABLE << 24) |       /* PAT3 */
+-                ((uint64_t)PAT_TYPE_UNCACHABLE << 32) |       /* PAT4 */
+-                ((uint64_t)PAT_TYPE_UNCACHABLE << 40) |       /* PAT5 */
+-                ((uint64_t)PAT_TYPE_UNCACHABLE << 48) |       /* PAT6 */
+-                ((uint64_t)PAT_TYPE_UNCACHABLE << 56);        /* PAT7 */
++                ((uint64_t)X86_MT_UC)       |       /* PAT0 */
++                ((uint64_t)X86_MT_UC << 8)  |       /* PAT1 */
++                ((uint64_t)X86_MT_UC << 16) |       /* PAT2 */
++                ((uint64_t)X86_MT_UC << 24) |       /* PAT3 */
++                ((uint64_t)X86_MT_UC << 32) |       /* PAT4 */
++                ((uint64_t)X86_MT_UC << 40) |       /* PAT5 */
++                ((uint64_t)X86_MT_UC << 48) |       /* PAT6 */
++                ((uint64_t)X86_MT_UC << 56);        /* PAT7 */
+ 
+             vmx_get_guest_pat(v, pat);
+             vmx_set_guest_pat(v, uc_pat);
+diff --git a/xen/arch/x86/include/asm/mtrr.h b/xen/arch/x86/include/asm/mtrr.h
+index 7733800b798fc2c72ba87e4ce6500e4183553d04..92fc930c692039b6c709d6a04f6553593f40aa55 100644
+--- a/xen/arch/x86/include/asm/mtrr.h
++++ b/xen/arch/x86/include/asm/mtrr.h
+@@ -16,17 +16,7 @@
+ #define NORMAL_CACHE_MODE          0
+ #define NO_FILL_CACHE_MODE         2
+ 
+-enum {
+-    PAT_TYPE_UNCACHABLE=0,
+-    PAT_TYPE_WRCOMB=1,
+-    PAT_TYPE_WRTHROUGH=4,
+-    PAT_TYPE_WRPROT=5,
+-    PAT_TYPE_WRBACK=6,
+-    PAT_TYPE_UC_MINUS=7,
+-    PAT_TYPE_NUMS
+-};
+-
+-#define INVALID_MEM_TYPE PAT_TYPE_NUMS
++#define INVALID_MEM_TYPE X86_NUM_MT
+ 
+ /* In the Intel processor's MTRR interface, the MTRR type is always held in
+    an 8 bit field: */
+diff --git a/xen/arch/x86/mm/p2m-ept.c b/xen/arch/x86/mm/p2m-ept.c
+index d61d66c20e4180f8cbe21bcd97b568519e0b738e..126437285d8a9f222fca6a7b6ff4434b60637847 100644
+--- a/xen/arch/x86/mm/p2m-ept.c
++++ b/xen/arch/x86/mm/p2m-ept.c
+@@ -573,8 +573,8 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+     if ( gmtrr_mtype >= 0 )
+     {
+         *ipat = true;
+-        return gmtrr_mtype != PAT_TYPE_UC_MINUS ? gmtrr_mtype
+-                                                : MTRR_TYPE_UNCACHABLE;
++        return gmtrr_mtype != X86_MT_UCM ? gmtrr_mtype
++                                         : MTRR_TYPE_UNCACHABLE;
+     }
+     if ( gmtrr_mtype == -EADDRNOTAVAIL )
+         return -1;
+diff --git a/xen/arch/x86/mm/shadow/multi.c b/xen/arch/x86/mm/shadow/multi.c
+index 6bb564b0145285afc93b72a60b7797fcfe8696dc..b64bba70fc17906236872a017ad48ce91fd30803 100644
+--- a/xen/arch/x86/mm/shadow/multi.c
++++ b/xen/arch/x86/mm/shadow/multi.c
+@@ -561,7 +561,7 @@ _sh_propagate(struct vcpu *v,
+              (type = hvm_get_mem_pinned_cacheattr(d, target_gfn, 0)) >= 0 )
+             sflags |= pat_type_2_pte_flags(type);
+         else if ( d->arch.hvm.is_in_uc_mode )
+-            sflags |= pat_type_2_pte_flags(PAT_TYPE_UNCACHABLE);
++            sflags |= pat_type_2_pte_flags(X86_MT_UC);
+         else
+             if ( iomem_access_permitted(d, mfn_x(target_mfn), mfn_x(target_mfn)) )
+             {
+@@ -572,7 +572,7 @@ _sh_propagate(struct vcpu *v,
+                             mfn_to_maddr(target_mfn),
+                             MTRR_TYPE_UNCACHABLE);
+                 else if ( iommu_snoop )
+-                    sflags |= pat_type_2_pte_flags(PAT_TYPE_WRBACK);
++                    sflags |= pat_type_2_pte_flags(X86_MT_WB);
+                 else
+                     sflags |= get_pat_flags(v,
+                             gflags,
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/0307-x86-Replace-MTRR_-constants-with-X86_MT_-constants.patch
+++ b/0307-x86-Replace-MTRR_-constants-with-X86_MT_-constants.patch
@@ -1,0 +1,418 @@
+From 6eaaa1fcb96438f35f69443cd375fe0b85595b7b Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 20 Dec 2022 16:50:38 +0100
+Subject: [PATCH 7/9] x86: Replace MTRR_* constants with X86_MT_* constants
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+This allows eliminating of the former, with the exception of
+MTRR_NUM_TYPES.  MTRR_NUM_TYPES is kept, as due to a quirk of the x86
+architecture X86_MT_UCM (7) is not valid in an MTRR.
+
+Suggested-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/cpu/mtrr/generic.c         | 10 ++---
+ xen/arch/x86/cpu/mtrr/main.c            | 26 ++++++-------
+ xen/arch/x86/e820.c                     |  4 +-
+ xen/arch/x86/hvm/mtrr.c                 | 30 +++++++--------
+ xen/arch/x86/hvm/vmx/vmcs.c             |  2 +-
+ xen/arch/x86/hvm/vmx/vmx.c              |  2 +-
+ xen/arch/x86/include/asm/hvm/vmx/vmcs.h |  2 +-
+ xen/arch/x86/include/asm/mtrr.h         | 10 +----
+ xen/arch/x86/mm/p2m-ept.c               | 51 ++++++++++++-------------
+ xen/arch/x86/mm/shadow/multi.c          |  2 +-
+ 10 files changed, 66 insertions(+), 73 deletions(-)
+
+diff --git a/xen/arch/x86/cpu/mtrr/generic.c b/xen/arch/x86/cpu/mtrr/generic.c
+index 47aaf76226e0a8a0712b7211ed339a4a032ab3f3..660ae26c2350b3436a471155fc0426699ba8ac1d 100644
+--- a/xen/arch/x86/cpu/mtrr/generic.c
++++ b/xen/arch/x86/cpu/mtrr/generic.c
+@@ -127,11 +127,11 @@ static const char *__init mtrr_attrib_to_str(mtrr_type x)
+ {
+ 	static const char __initconst strings[MTRR_NUM_TYPES][16] =
+ 	{
+-		[MTRR_TYPE_UNCACHABLE]     = "uncachable",
+-		[MTRR_TYPE_WRCOMB]         = "write-combining",
+-		[MTRR_TYPE_WRTHROUGH]      = "write-through",
+-		[MTRR_TYPE_WRPROT]         = "write-protect",
+-		[MTRR_TYPE_WRBACK]         = "write-back",
++		[X86_MT_UC] = "uncachable",
++		[X86_MT_WC] = "write-combining",
++		[X86_MT_WT] = "write-through",
++		[X86_MT_WP] = "write-protect",
++		[X86_MT_WB] = "write-back",
+ 	};
+ 
+ 	return (x < ARRAY_SIZE(strings) && strings[x][0]) ? strings[x] : "?";
+diff --git a/xen/arch/x86/cpu/mtrr/main.c b/xen/arch/x86/cpu/mtrr/main.c
+index 4e01c8d6f9df6562b94438f265d79a0a6fca8de6..2946003b84938f3b83c98b62dfaa3ace90822983 100644
+--- a/xen/arch/x86/cpu/mtrr/main.c
++++ b/xen/arch/x86/cpu/mtrr/main.c
+@@ -163,10 +163,10 @@ static void cf_check ipi_handler(void *info)
+ }
+ 
+ static inline int types_compatible(mtrr_type type1, mtrr_type type2) {
+-	return type1 == MTRR_TYPE_UNCACHABLE ||
+-	       type2 == MTRR_TYPE_UNCACHABLE ||
+-	       (type1 == MTRR_TYPE_WRTHROUGH && type2 == MTRR_TYPE_WRBACK) ||
+-	       (type1 == MTRR_TYPE_WRBACK && type2 == MTRR_TYPE_WRTHROUGH);
++	return type1 == X86_MT_UC ||
++	       type2 == X86_MT_UC ||
++	       (type1 == X86_MT_WT && type2 == X86_MT_WB) ||
++	       (type1 == X86_MT_WB && type2 == X86_MT_WT);
+ }
+ 
+ /**
+@@ -297,13 +297,13 @@ static void set_mtrr(unsigned int reg, unsigned long base,
+  *
+  *	The available types are
+  *
+- *	%MTRR_TYPE_UNCACHABLE	-	No caching
++ *	%X86_MT_UC	-	No caching
+  *
+- *	%MTRR_TYPE_WRBACK	-	Write data back in bursts whenever
++ *	%X86_MT_WB	-	Write data back in bursts whenever
+  *
+- *	%MTRR_TYPE_WRCOMB	-	Write data back soon but allow bursts
++ *	%X86_MT_WC	-	Write data back soon but allow bursts
+  *
+- *	%MTRR_TYPE_WRTHROUGH	-	Cache reads but not writes
++ *	%X86_MT_WT	-	Cache reads but not writes
+  *
+  *	BUGS: Needs a quiet flag for the cases where drivers do not mind
+  *	failures and do not wish system log messages to be sent.
+@@ -328,7 +328,7 @@ int mtrr_add_page(unsigned long base, unsigned long size,
+ 	}
+ 
+ 	/*  If the type is WC, check that this processor supports it  */
+-	if ((type == MTRR_TYPE_WRCOMB) && !have_wrcomb()) {
++	if ((type == X86_MT_WC) && !have_wrcomb()) {
+ 		printk(KERN_WARNING
+ 		       "mtrr: your processor doesn't support write-combining\n");
+ 		return -EOPNOTSUPP;
+@@ -442,13 +442,13 @@ static int mtrr_check(unsigned long base, unsigned long size)
+  *
+  *	The available types are
+  *
+- *	%MTRR_TYPE_UNCACHABLE	-	No caching
++ *	%X86_MT_UC	-	No caching
+  *
+- *	%MTRR_TYPE_WRBACK	-	Write data back in bursts whenever
++ *	%X86_MT_WB	-	Write data back in bursts whenever
+  *
+- *	%MTRR_TYPE_WRCOMB	-	Write data back soon but allow bursts
++ *	%X86_MT_WC	-	Write data back soon but allow bursts
+  *
+- *	%MTRR_TYPE_WRTHROUGH	-	Cache reads but not writes
++ *	%X86_MT_WT	-	Cache reads but not writes
+  *
+  *	BUGS: Needs a quiet flag for the cases where drivers do not mind
+  *	failures and do not wish system log messages to be sent.
+diff --git a/xen/arch/x86/e820.c b/xen/arch/x86/e820.c
+index b653a19c93afb98c2d64330384cb4fa7b4d2e1ec..c5911cf48dc4a281c03ddef35f23b19bc7af42eb 100644
+--- a/xen/arch/x86/e820.c
++++ b/xen/arch/x86/e820.c
+@@ -459,7 +459,7 @@ static uint64_t __init mtrr_top_of_ram(void)
+         printk(" MTRR cap: %"PRIx64" type: %"PRIx64"\n", mtrr_cap, mtrr_def);
+ 
+     /* MTRRs enabled, and default memory type is not writeback? */
+-    if ( !test_bit(11, &mtrr_def) || ((uint8_t)mtrr_def == MTRR_TYPE_WRBACK) )
++    if ( !test_bit(11, &mtrr_def) || ((uint8_t)mtrr_def == X86_MT_WB) )
+         return 0;
+ 
+     /*
+@@ -476,7 +476,7 @@ static uint64_t __init mtrr_top_of_ram(void)
+             printk(" MTRR[%d]: base %"PRIx64" mask %"PRIx64"\n",
+                    i, base, mask);
+ 
+-        if ( !test_bit(11, &mask) || ((uint8_t)base != MTRR_TYPE_WRBACK) )
++        if ( !test_bit(11, &mask) || ((uint8_t)base != X86_MT_WB) )
+             continue;
+         base &= addr_mask;
+         mask &= addr_mask;
+diff --git a/xen/arch/x86/hvm/mtrr.c b/xen/arch/x86/hvm/mtrr.c
+index 242623f3c239ee18a44f882ecb3910a00c615825..093103f6c768cf64f880d1b20e1c14f5918c1250 100644
+--- a/xen/arch/x86/hvm/mtrr.c
++++ b/xen/arch/x86/hvm/mtrr.c
+@@ -39,11 +39,11 @@ static const uint8_t pat_entry_2_pte_flags[8] = {
+ /* Effective mm type lookup table, according to MTRR and PAT. */
+ static const uint8_t mm_type_tbl[MTRR_NUM_TYPES][X86_NUM_MT] = {
+ #define RS MEMORY_NUM_TYPES
+-#define UC MTRR_TYPE_UNCACHABLE
+-#define WB MTRR_TYPE_WRBACK
+-#define WC MTRR_TYPE_WRCOMB
+-#define WP MTRR_TYPE_WRPROT
+-#define WT MTRR_TYPE_WRTHROUGH
++#define UC X86_MT_UC
++#define WB X86_MT_WB
++#define WC X86_MT_WC
++#define WP X86_MT_WP
++#define WT X86_MT_WT
+ 
+ /*          PAT(UC, WC, RS, RS, WT, WP, WB, UC-) */
+ /* MTRR(UC) */ {UC, WC, RS, RS, UC, UC, UC, UC},
+@@ -202,7 +202,7 @@ int mtrr_get_type(const struct mtrr_state *m, paddr_t pa, unsigned int order)
+    unsigned int seg, num_var_ranges = MASK_EXTR(m->mtrr_cap, MTRRcap_VCNT);
+ 
+    if ( unlikely(!m->enabled) )
+-       return MTRR_TYPE_UNCACHABLE;
++       return X86_MT_UC;
+ 
+    pa &= mask;
+    if ( (pa < 0x100000) && m->fixed_enabled )
+@@ -277,13 +277,13 @@ int mtrr_get_type(const struct mtrr_state *m, paddr_t pa, unsigned int order)
+        return -1;
+ 
+    /* Two or more matches, one being UC? */
+-   if ( overlap_mtrr & (1 << MTRR_TYPE_UNCACHABLE) )
+-       return MTRR_TYPE_UNCACHABLE;
++   if ( overlap_mtrr & (1 << X86_MT_UC) )
++       return X86_MT_UC;
+ 
+    /* Two or more matches, all of them WT and WB? */
+    if ( overlap_mtrr ==
+-        ((1 << MTRR_TYPE_WRTHROUGH) | (1 << MTRR_TYPE_WRBACK)) )
+-       return MTRR_TYPE_WRTHROUGH;
++        ((1 << X86_MT_WT) | (1 << X86_MT_WB)) )
++       return X86_MT_WT;
+ 
+    /* Behaviour is undefined, but return the last overlapped type. */
+    return overlap_mtrr_pos;
+@@ -381,11 +381,11 @@ static inline bool_t valid_mtrr_type(uint8_t type)
+ {
+     switch ( type )
+     {
+-    case MTRR_TYPE_UNCACHABLE:
+-    case MTRR_TYPE_WRBACK:
+-    case MTRR_TYPE_WRCOMB:
+-    case MTRR_TYPE_WRPROT:
+-    case MTRR_TYPE_WRTHROUGH:
++    case X86_MT_UC:
++    case X86_MT_WB:
++    case X86_MT_WC:
++    case X86_MT_WP:
++    case X86_MT_WT:
+         return 1;
+     }
+     return 0;
+diff --git a/xen/arch/x86/hvm/vmx/vmcs.c b/xen/arch/x86/hvm/vmx/vmcs.c
+index 84dbb88d33b76111833a37339186199f8bc03b5e..f0825216d722d978f221bb34a797d8de5505cb80 100644
+--- a/xen/arch/x86/hvm/vmx/vmcs.c
++++ b/xen/arch/x86/hvm/vmx/vmcs.c
+@@ -555,7 +555,7 @@ static int vmx_init_vmcs_config(bool bsp)
+     /* Require Write-Back (WB) memory type for VMCS accesses. */
+     opt = (vmx_basic_msr_high & (VMX_BASIC_MEMORY_TYPE_MASK >> 32)) /
+           ((VMX_BASIC_MEMORY_TYPE_MASK & -VMX_BASIC_MEMORY_TYPE_MASK) >> 32);
+-    if ( opt != MTRR_TYPE_WRBACK )
++    if ( opt != X86_MT_WB )
+     {
+         printk("VMX: CPU%d has unexpected VMCS access type %u\n",
+                smp_processor_id(), opt);
+diff --git a/xen/arch/x86/hvm/vmx/vmx.c b/xen/arch/x86/hvm/vmx/vmx.c
+index b543c3983d77ae807e8bd97330691a79d8d39bae..4ae7dd56c9981d32ac545d6e7b7c126b15f68969 100644
+--- a/xen/arch/x86/hvm/vmx/vmx.c
++++ b/xen/arch/x86/hvm/vmx/vmx.c
+@@ -434,7 +434,7 @@ static void cf_check domain_creation_finished(struct domain *d)
+         return;
+ 
+     ASSERT(epte_get_entry_emt(d, gfn, apic_access_mfn, 0, &ipat,
+-                              p2m_mmio_direct) == MTRR_TYPE_WRBACK);
++                              p2m_mmio_direct) == X86_MT_WB);
+     ASSERT(ipat);
+ 
+     if ( set_mmio_p2m_entry(d, gfn, apic_access_mfn, PAGE_ORDER_4K) )
+diff --git a/xen/arch/x86/include/asm/hvm/vmx/vmcs.h b/xen/arch/x86/include/asm/hvm/vmx/vmcs.h
+index 75f9928abfad28e3895fe3dd4058b2b0a6e145c3..65e9e27b5437adff59abc46976f73a9f2cc587da 100644
+--- a/xen/arch/x86/include/asm/hvm/vmx/vmcs.h
++++ b/xen/arch/x86/include/asm/hvm/vmx/vmcs.h
+@@ -38,7 +38,7 @@ struct vmx_msr_entry {
+     u64 data;
+ };
+ 
+-#define EPT_DEFAULT_MT      MTRR_TYPE_WRBACK
++#define EPT_DEFAULT_MT      X86_MT_WB
+ 
+ struct ept_data {
+     union {
+diff --git a/xen/arch/x86/include/asm/mtrr.h b/xen/arch/x86/include/asm/mtrr.h
+index 92fc930c692039b6c709d6a04f6553593f40aa55..e4f6ca6048334b2094a1836cc2f298453641232f 100644
+--- a/xen/arch/x86/include/asm/mtrr.h
++++ b/xen/arch/x86/include/asm/mtrr.h
+@@ -3,15 +3,9 @@
+ 
+ #include <xen/mm.h>
+ 
+-/* These are the region types. They match the architectural specification. */
+-#define MTRR_TYPE_UNCACHABLE 0
+-#define MTRR_TYPE_WRCOMB     1
+-#define MTRR_TYPE_WRTHROUGH  4
+-#define MTRR_TYPE_WRPROT     5
+-#define MTRR_TYPE_WRBACK     6
+-#define MTRR_NUM_TYPES       7
++#define MTRR_NUM_TYPES       X86_MT_UCM
+ #define MEMORY_NUM_TYPES     MTRR_NUM_TYPES
+-#define NO_HARDCODE_MEM_TYPE    MTRR_NUM_TYPES
++#define NO_HARDCODE_MEM_TYPE MTRR_NUM_TYPES
+ 
+ #define NORMAL_CACHE_MODE          0
+ #define NO_FILL_CACHE_MODE         2
+diff --git a/xen/arch/x86/mm/p2m-ept.c b/xen/arch/x86/mm/p2m-ept.c
+index 126437285d8a9f222fca6a7b6ff4434b60637847..bb143c6c42c69db4e054b9156aad9a18ea0b2378 100644
+--- a/xen/arch/x86/mm/p2m-ept.c
++++ b/xen/arch/x86/mm/p2m-ept.c
+@@ -506,7 +506,7 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+                                                mfn_x(mfn) | ((1UL << order) - 1)) )
+         {
+             *ipat = true;
+-            return MTRR_TYPE_UNCACHABLE;
++            return X86_MT_UC;
+         }
+         /* Force invalid memory type so resolve_misconfig() will split it */
+         return -1;
+@@ -515,7 +515,7 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+     if ( !mfn_valid(mfn) )
+     {
+         *ipat = true;
+-        return MTRR_TYPE_UNCACHABLE;
++        return X86_MT_UC;
+     }
+ 
+     /*
+@@ -526,7 +526,7 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+          !cache_flush_permitted(d) )
+     {
+         *ipat = true;
+-        return MTRR_TYPE_WRBACK;
++        return X86_MT_WB;
+     }
+ 
+     for ( special_pgs = i = 0; i < (1ul << order); i++ )
+@@ -539,13 +539,13 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+             return -1;
+ 
+         *ipat = true;
+-        return MTRR_TYPE_WRBACK;
++        return X86_MT_WB;
+     }
+ 
+     switch ( type )
+     {
+     case p2m_mmio_direct:
+-        return MTRR_TYPE_UNCACHABLE;
++        return X86_MT_UC;
+ 
+     case p2m_grant_map_ro:
+     case p2m_grant_map_rw:
+@@ -563,7 +563,7 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+          * diverges. See p2m_type_to_flags for the AMD attributes.
+          */
+         *ipat = true;
+-        return MTRR_TYPE_WRBACK;
++        return X86_MT_WB;
+ 
+     default:
+         break;
+@@ -573,15 +573,14 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+     if ( gmtrr_mtype >= 0 )
+     {
+         *ipat = true;
+-        return gmtrr_mtype != X86_MT_UCM ? gmtrr_mtype
+-                                         : MTRR_TYPE_UNCACHABLE;
++        return gmtrr_mtype != X86_MT_UCM ? gmtrr_mtype : X86_MT_UC;
+     }
+     if ( gmtrr_mtype == -EADDRNOTAVAIL )
+         return -1;
+ 
+     gmtrr_mtype = v ? mtrr_get_type(&v->arch.hvm.mtrr,
+                                     gfn_x(gfn) << PAGE_SHIFT, order)
+-                    : MTRR_TYPE_WRBACK;
++                    : X86_MT_WB;
+     hmtrr_mtype = mtrr_get_type(&mtrr_state, mfn_x(mfn) << PAGE_SHIFT,
+                                 order);
+     if ( gmtrr_mtype < 0 || hmtrr_mtype < 0 )
+@@ -592,14 +591,14 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+         return hmtrr_mtype;
+ 
+     /* If either type is UC, we have to go with that one. */
+-    if ( gmtrr_mtype == MTRR_TYPE_UNCACHABLE ||
+-         hmtrr_mtype == MTRR_TYPE_UNCACHABLE )
+-        return MTRR_TYPE_UNCACHABLE;
++    if ( gmtrr_mtype == X86_MT_UC ||
++         hmtrr_mtype == X86_MT_UC )
++        return X86_MT_UC;
+ 
+     /* If either type is WB, we have to go with the other one. */
+-    if ( gmtrr_mtype == MTRR_TYPE_WRBACK )
++    if ( gmtrr_mtype == X86_MT_WB )
+         return hmtrr_mtype;
+-    if ( hmtrr_mtype == MTRR_TYPE_WRBACK )
++    if ( hmtrr_mtype == X86_MT_WB )
+         return gmtrr_mtype;
+ 
+     /*
+@@ -610,13 +609,13 @@ int epte_get_entry_emt(struct domain *d, gfn_t gfn, mfn_t mfn,
+      * permit this), while WT and WP require writes to go straight to memory
+      * (WC can buffer them).
+      */
+-    if ( (gmtrr_mtype == MTRR_TYPE_WRTHROUGH &&
+-          hmtrr_mtype == MTRR_TYPE_WRPROT) ||
+-         (gmtrr_mtype == MTRR_TYPE_WRPROT &&
+-          hmtrr_mtype == MTRR_TYPE_WRTHROUGH) )
+-        return MTRR_TYPE_WRPROT;
++    if ( (gmtrr_mtype == X86_MT_WT &&
++          hmtrr_mtype == X86_MT_WP) ||
++         (gmtrr_mtype == X86_MT_WP &&
++          hmtrr_mtype == X86_MT_WT) )
++        return X86_MT_WP;
+ 
+-    return MTRR_TYPE_UNCACHABLE;
++    return X86_MT_UC;
+ }
+ 
+ /*
+@@ -1426,12 +1425,12 @@ void ept_p2m_uninit(struct p2m_domain *p2m)
+ static const char *memory_type_to_str(unsigned int x)
+ {
+     static const char memory_types[8][3] = {
+-        [MTRR_TYPE_UNCACHABLE]     = "UC",
+-        [MTRR_TYPE_WRCOMB]         = "WC",
+-        [MTRR_TYPE_WRTHROUGH]      = "WT",
+-        [MTRR_TYPE_WRPROT]         = "WP",
+-        [MTRR_TYPE_WRBACK]         = "WB",
+-        [MTRR_NUM_TYPES]           = "??"
++        [X86_MT_UC]      = "UC",
++        [X86_MT_WC]      = "WC",
++        [X86_MT_WT]      = "WT",
++        [X86_MT_WP]      = "WP",
++        [X86_MT_WB]      = "WB",
++        [MTRR_NUM_TYPES] = "??",
+     };
+ 
+     ASSERT(x < ARRAY_SIZE(memory_types));
+diff --git a/xen/arch/x86/mm/shadow/multi.c b/xen/arch/x86/mm/shadow/multi.c
+index b64bba70fc17906236872a017ad48ce91fd30803..f5f7ff021bd9e057c5b6f6329de7acb5ef05d58f 100644
+--- a/xen/arch/x86/mm/shadow/multi.c
++++ b/xen/arch/x86/mm/shadow/multi.c
+@@ -570,7 +570,7 @@ _sh_propagate(struct vcpu *v,
+                             gflags,
+                             gfn_to_paddr(target_gfn),
+                             mfn_to_maddr(target_mfn),
+-                            MTRR_TYPE_UNCACHABLE);
++                            X86_MT_UC);
+                 else if ( iommu_snoop )
+                     sflags |= pat_type_2_pte_flags(X86_MT_WB);
+                 else
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/0308-x86-Replace-EPT_EMT_-constants-with-X86_MT_.patch
+++ b/0308-x86-Replace-EPT_EMT_-constants-with-X86_MT_.patch
@@ -1,0 +1,64 @@
+From b7dd0f590aa69431f26f825ae3d568623ee7fe54 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 20 Dec 2022 16:51:18 +0100
+Subject: [PATCH 8/9] x86: Replace EPT_EMT_* constants with X86_MT_*
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+This allows eliminating the former.  No functional change intended.
+
+Suggested-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/include/asm/hvm/vmx/vmx.h | 9 ---------
+ xen/arch/x86/mm/hap/nested_ept.c       | 4 ++--
+ 2 files changed, 2 insertions(+), 11 deletions(-)
+
+diff --git a/xen/arch/x86/include/asm/hvm/vmx/vmx.h b/xen/arch/x86/include/asm/hvm/vmx/vmx.h
+index 8eedf59155e01ec1ca84dcc6b30961f9c884cb3b..49fe9822fac5eae15b67f0cfd3d0cb96347dc7ed 100644
+--- a/xen/arch/x86/include/asm/hvm/vmx/vmx.h
++++ b/xen/arch/x86/include/asm/hvm/vmx/vmx.h
+@@ -80,15 +80,6 @@ typedef enum {
+ #define EPTE_RWX_MASK           0x7
+ #define EPTE_FLAG_MASK          0x7f
+ 
+-#define EPT_EMT_UC              0
+-#define EPT_EMT_WC              1
+-#define EPT_EMT_RSV0            2
+-#define EPT_EMT_RSV1            3
+-#define EPT_EMT_WT              4
+-#define EPT_EMT_WP              5
+-#define EPT_EMT_WB              6
+-#define EPT_EMT_RSV2            7
+-
+ #define PI_xAPIC_NDST_MASK      0xFF00
+ 
+ void vmx_asm_vmexit_handler(struct cpu_user_regs);
+diff --git a/xen/arch/x86/mm/hap/nested_ept.c b/xen/arch/x86/mm/hap/nested_ept.c
+index 1cb7fefc37091bf7d92a277203e652add5611871..23fb3889b7605be62805731218c314819d5027b5 100644
+--- a/xen/arch/x86/mm/hap/nested_ept.c
++++ b/xen/arch/x86/mm/hap/nested_ept.c
+@@ -84,8 +84,8 @@ static bool_t nept_emt_bits_check(ept_entry_t e, uint32_t level)
+ {
+     if ( e.sp || level == 1 )
+     {
+-        if ( e.emt == EPT_EMT_RSV0 || e.emt == EPT_EMT_RSV1 ||
+-             e.emt == EPT_EMT_RSV2 )
++        if ( e.emt == X86_MT_RSVD_2 || e.emt == X86_MT_RSVD_3 ||
++             e.emt == X86_MT_UCM )
+             return 1;
+     }
+     return 0;
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/0309-x86-Derive-XEN_MSR_PAT-from-its-individual-entries.patch
+++ b/0309-x86-Derive-XEN_MSR_PAT-from-its-individual-entries.patch
@@ -1,0 +1,72 @@
+From 4b40d68e663e87eb916b5bdf3da9743a17f43537 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 20 Dec 2022 16:51:55 +0100
+Subject: [PATCH 9/9] x86: Derive XEN_MSR_PAT from its individual entries
+To: xen-devel@lists.xenproject.org
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>,
+    Jan Beulich <jbeulich@suse.com>,
+    Andrew Cooper <andrew.cooper3@citrix.com>,
+    "Roger Pau Monné" <roger.pau@citrix.com>,
+    Wei Liu <wl@xen.org>,
+    Jun Nakajima <jun.nakajima@intel.com>,
+    Kevin Tian <kevin.tian@intel.com>,
+    George Dunlap <george.dunlap@citrix.com>,
+    Tim Deegan <tim@xen.org>
+
+This avoids it being a magic constant that is difficult for humans to
+decode.  Use BUILD_BUG_ON to check that the old and new values are
+identical.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/include/asm/processor.h |  9 ++++++++-
+ xen/arch/x86/mm.c                    | 11 +++++++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/xen/arch/x86/include/asm/processor.h b/xen/arch/x86/include/asm/processor.h
+index 8e2816fae9b97bd4e153a30cc3802971fe0355af..60b902060914584957db8afa5c7c1e6abdad4d13 100644
+--- a/xen/arch/x86/include/asm/processor.h
++++ b/xen/arch/x86/include/asm/processor.h
+@@ -96,7 +96,14 @@
+  * Host IA32_CR_PAT value to cover all memory types.  This is not the default
+  * MSR_PAT value, and is an ABI with PV guests.
+  */
+-#define XEN_MSR_PAT _AC(0x050100070406, ULL)
++#define XEN_MSR_PAT ((_AC(X86_MT_WB,  ULL) << 0x00) | \
++                     (_AC(X86_MT_WT,  ULL) << 0x08) | \
++                     (_AC(X86_MT_UCM, ULL) << 0x10) | \
++                     (_AC(X86_MT_UC,  ULL) << 0x18) | \
++                     (_AC(X86_MT_WC,  ULL) << 0x20) | \
++                     (_AC(X86_MT_WP,  ULL) << 0x28) | \
++                     (_AC(X86_MT_UC,  ULL) << 0x30) | \
++                     (_AC(X86_MT_UC,  ULL) << 0x38))
+ 
+ #ifndef __ASSEMBLY__
+ 
+diff --git a/xen/arch/x86/mm.c b/xen/arch/x86/mm.c
+index 78b1972e4170cacccc9c37c6e64e76e66a7da87f..84dcec34b9ad8d5d6024667a14875eae86fdb267 100644
+--- a/xen/arch/x86/mm.c
++++ b/xen/arch/x86/mm.c
+@@ -6350,6 +6350,17 @@ unsigned long get_upper_mfn_bound(void)
+     return min(max_mfn, 1UL << (paddr_bits - PAGE_SHIFT)) - 1;
+ }
+ 
++static void __init __maybe_unused build_assertions(void)
++{
++    /*
++     * If this trips, any guests that blindly rely on the public API in xen.h
++     * (instead of reading the PAT from Xen, as Linux 3.19+ does) will be
++     * broken.  Furthermore, live migration of PV guests between Xen versions
++     * using different PATs will not work.
++     */
++    BUILD_BUG_ON(XEN_MSR_PAT != 0x050100070406ULL);
++}
++
+ /*
+  * Local variables:
+  * mode: C
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -99,6 +99,17 @@ Patch0201: 0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch
 Patch0202: 0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
 Patch0203: 0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
 
+# Backports
+Patch0301: 0301-x86-mm-shadow-avoid-assuming-a-specific-Xen-PAT.patch
+Patch0302: 0302-x86-mm-shadow-do-not-open-code-PAGE_CACHE_ATTRS.patch
+Patch0303: 0303-p2m-pt-Avoid-hard-coding-Xen-s-PAT.patch
+Patch0304: 0304-efi-Avoid-hard-coding-the-various-PAT-constants.patch
+Patch0305: 0305-x86-Add-memory-type-constants.patch
+Patch0306: 0306-x86-Replace-PAT_-with-X86_MT_.patch
+Patch0307: 0307-x86-Replace-MTRR_-constants-with-X86_MT_-constants.patch
+Patch0308: 0308-x86-Replace-EPT_EMT_-constants-with-X86_MT_.patch
+Patch0309: 0309-x86-Derive-XEN_MSR_PAT-from-its-individual-entries.patch
+
 # Upstreamable patches
 Patch0604: 0604-libxl-create-writable-error-xenstore-dir.patch
 Patch0605: 0605-libxl-do-not-wait-for-backend-on-PCI-remove-when-bac.patch


### PR DESCRIPTION
They are prerequisites for subsequent PAT changes that Qubes might also want to backport, and (unlike the others) have already been comitted upstream.