### PR TITLE
Do not override stub grub.cfg on EFI partition

### DIFF
--- a/xen.spec.in
+++ b/xen.spec.in
@@ -712,7 +712,8 @@ if [ $1 == 1 -a -f /sbin/grub2-mkconfig ]; then
   if [ -f /boot/grub2/grub.cfg ]; then
     /sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
   fi
-  if [ -f /boot/efi/EFI/qubes/grub.cfg ]; then
+  if [ -f /boot/efi/EFI/qubes/grub.cfg ] && \
+        ! grep -q "configfile" /boot/efi/EFI/qubes/grub.cfg; then
     /sbin/grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg
   fi
 fi
@@ -722,7 +723,8 @@ if [ -f /sbin/grub2-mkconfig ]; then
   if [ -f /boot/grub2/grub.cfg ]; then
     /sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
   fi
-  if [ -f /boot/efi/EFI/qubes/grub.cfg ]; then
+  if [ -f /boot/efi/EFI/qubes/grub.cfg ] && \
+        ! grep -q "configfile" /boot/efi/EFI/qubes/grub.cfg; then
     /sbin/grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg
   fi
 fi


### PR DESCRIPTION
Grub2 in R4.2 is made to include grub.cfg from primary /boot partition,
even on EFI systems - so it always lives in the same place. Do not not
override the config stub.

QubesOS/qubes-issues#7985