### PR TITLE
Recover some performance from unneeded speculative workarounds

### DIFF
--- a/1020-xen-tell-guests-what-speculative-workarounds-are-not.patch
+++ b/1020-xen-tell-guests-what-speculative-workarounds-are-not.patch
@@ -1,0 +1,36 @@
+From 6a3be9a4d752ecc5af6fb61dbfc8f53a948c2556 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Thu, 2 Feb 2023 20:42:27 +0100
+Subject: [PATCH] xen: tell guests what speculative workarounds are not
+ necessary
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Expose arch caps to guests, so the guest kernel can do a better choice
+what workarounds are necessary on a given platform. This is
+fundamentally incompatible with migration, but since we don't do
+migration, we can recover some performance.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ xen/arch/x86/msr.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xen/arch/x86/msr.c b/xen/arch/x86/msr.c
+index 317b154d244d..140a3c297be0 100644
+--- a/xen/arch/x86/msr.c
++++ b/xen/arch/x86/msr.c
+@@ -157,7 +157,7 @@ int init_domain_msr_policy(struct domain *d)
+      * so dom0 can turn off workarounds as appropriate.  Temporary, until the
+      * domain policy logic gains a better understanding of MSRs.
+      */
+-    if ( is_hardware_domain(d) && cpu_has_arch_caps )
++    if ( cpu_has_arch_caps )
+     {
+         uint64_t val;
+ 
+-- 
+2.37.3
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -158,6 +158,7 @@ Patch1016: 1016-gnttab-disable-grant-tables-v2-by-default.patch
 Patch1017: 1017-Disable-TSX-by-default.patch
 Patch1018: 1018-Fix-IGD-passthrough-with-linux-stubdomain.patch
 Patch1019: 1019-Use-Linux-s-PAT.patch
+Patch1020: 1020-xen-tell-guests-what-speculative-workarounds-are-not.patch
 
 # Reproducible builds
 Patch1100: 1100-Define-build-dates-time-based-on-SOURCE_DATE_EPOCH.patch


### PR DESCRIPTION
Tell guest kernel what fixes are already available in the hardware, so
it can turn off some of the workarounds. This especially helps on newer
CPUs.