### PR TITLE
Fix build for GCC 13.1

### DIFF
--- a/patch-0001-libxc-fix-compilation-error-with-gcc13.patch
+++ b/patch-0001-libxc-fix-compilation-error-with-gcc13.patch
@@ -1,0 +1,32 @@
+From edfc07cc7aa253412131c659984827da691684a5 Mon Sep 17 00:00:00 2001
+From: Charles Arnold <carnold@suse.com>
+Date: Wed, 6 Jul 2022 13:06:40 +0200
+Subject: [PATCH] libxc: fix compilation error with gcc13
+
+xc_psr.c:161:5: error: conflicting types for 'xc_psr_cmt_get_data'
+due to enum/integer mismatch;
+
+Signed-off-by: Charles Arnold <carnold@suse.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Anthony PERARD <anthony.perard@citrix.com>
+(cherry picked from commit 8eeae8c2b4efefda8e946461e86cf2ae9c18e5a9)
+---
+ tools/libxc/include/xenctrl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/libxc/include/xenctrl.h b/tools/libxc/include/xenctrl.h
+index 4c89b7294c..3e27202149 100644
+--- a/tools/libxc/include/xenctrl.h
++++ b/tools/libxc/include/xenctrl.h
+@@ -2506,7 +2506,7 @@ int xc_psr_cmt_get_l3_event_mask(xc_interface *xch, uint32_t *event_mask);
+ int xc_psr_cmt_get_l3_cache_size(xc_interface *xch, uint32_t cpu,
+                                  uint32_t *l3_cache_size);
+ int xc_psr_cmt_get_data(xc_interface *xch, uint32_t rmid, uint32_t cpu,
+-                        uint32_t psr_cmt_type, uint64_t *monitor_data,
++                        xc_psr_cmt_type type, uint64_t *monitor_data,
+                         uint64_t *tsc);
+ int xc_psr_cmt_enabled(xc_interface *xch);
+ 
+-- 
+2.40.0
+

--- a/series-vm.conf
+++ b/series-vm.conf
@@ -10,3 +10,4 @@ patch-docs-xen-headers-use-alphabetical-sorting-for-incont.patch
 patch-Strip-build-path-directories-in-tools-xen-and-xen-ar.patch
 patch-x86-deal-with-gcc12-release-build-issues.patch
 patch-IOMMU-x86-work-around-bogus-gcc12-warning-in-hvm_gsi.patch
+patch-0001-libxc-fix-compilation-error-with-gcc13.patch


### PR DESCRIPTION
This closes https://github.com/QubesOS/qubes-issues/issues/8208. Arch Linux [now uses `gcc 13.1.1-1`](https://archlinux.org/packages/core/x86_64/gcc/), which has among [its C changes](https://gcc.gnu.org/gcc-13/changes.html) this:
> New warnings:
>
> - [-Wenum-int-mismatch](https://gcc.gnu.org/onlinedocs/gcc-13.1.0/gcc/Warning-Options.html#index-Wenum-int-mismatch) warns about mismatches between an enumerated type and an integer type ([PR105131](https://gcc.gnu.org/PR105131))

So building `vmm-xen` on Arch now results in:
```
xc_psr.c:161:5: error: conflicting types for ‘xc_psr_cmt_get_data’ due to enum/integer mismatch; have ‘int(xc_interface *, uint32_t,  uint32_t,  xc_psr_cmt_type,  uint64_t *, uint64_t *)’ {aka ‘int(struct xc_interface_core *, unsigned int,  unsigned int,  xc_psr_cmt_type,  long unsigned int *, long unsigned int *)’} [-Werror=enum-int-mismatch]
  161 | int xc_psr_cmt_get_data(xc_interface *xch, uint32_t rmid, uint32_t cpu,
      |     ^~~~~~~~~~~~~~~~~~~
In file included from xc_private.h:35,
                 from xc_psr.c:21:
./include/xenctrl.h:2508:5: note: previous declaration of ‘xc_psr_cmt_get_data’ with type ‘int(xc_interface *, uint32_t,  uint32_t,  uint32_t,  uint64_t *, uint64_t *)’ {aka ‘int(struct xc_interface_core *, unsigned int,  unsigned int,  unsigned int,  long unsigned int *, long unsigned int *)’}
 2508 | int xc_psr_cmt_get_data(xc_interface *xch, uint32_t rmid, uint32_t cpu,
      |     ^~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

Because of changes to the folder structure, I needed to backport https://github.com/xen-project/xen/commit/8eeae8c2b4efefda8e946461e86cf2ae9c18e5a9 to the xen-4.14 tree, but `git cherry-pick -x 8eeae8c2b4efefda8e946461e86cf2ae9c18e5a9; git format-patch -1` seems to have worked well enough on top of the `RELEASE-4.14.5` xen tag to handle it automatically :crossed_fingers: 