### PR TITLE
Apply patches for MSI-X support with stubdomain (4.17)

### DIFF
--- a/patch-msix-0001-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
+++ b/patch-msix-0001-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
@@ -1,0 +1,68 @@
+From fe591cbc1568d3952d877ef54f26d9cd4543dfa1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 14 Nov 2022 13:56:56 +0100
+Subject: [PATCH 1/2] x86/msi: passthrough all MSI-X vector ctrl writes to
+ device model
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+QEMU needs to know whether clearing maskbit of a vector is really
+clearing, or was already cleared before. Currently Xen sends only
+clearing that bit to the device model, but not setting it, so QEMU
+cannot detect it. Because of that, QEMU is working this around by
+checking via /dev/mem, but that isn't the proper approach.
+
+Give all necessary information to QEMU by passing all ctrl writes,
+including masking a vector.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ xen/arch/x86/hvm/vmsi.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/xen/arch/x86/hvm/vmsi.c b/xen/arch/x86/hvm/vmsi.c
+index 75f92885dc5e..ba4cf46dfe91 100644
+--- a/xen/arch/x86/hvm/vmsi.c
++++ b/xen/arch/x86/hvm/vmsi.c
+@@ -271,7 +271,8 @@ out:
+ }
+ 
+ static int msixtbl_write(struct vcpu *v, unsigned long address,
+-                         unsigned int len, unsigned long val)
++                         unsigned int len, unsigned long val,
++                         bool completion)
+ {
+     unsigned long offset;
+     struct msixtbl_entry *entry;
+@@ -343,7 +344,7 @@ static int msixtbl_write(struct vcpu *v, unsigned long address,
+ 
+ unlock:
+     spin_unlock_irqrestore(&desc->lock, flags);
+-    if ( len == 4 )
++    if ( len == 4 && completion )
+         r = X86EMUL_OKAY;
+ 
+ out:
+@@ -355,7 +356,7 @@ static int cf_check _msixtbl_write(
+     const struct hvm_io_handler *handler, uint64_t address, uint32_t len,
+     uint64_t val)
+ {
+-    return msixtbl_write(current, address, len, val);
++    return msixtbl_write(current, address, len, val, false);
+ }
+ 
+ static bool cf_check msixtbl_range(
+@@ -633,7 +634,7 @@ void msix_write_completion(struct vcpu *v)
+         return;
+ 
+     v->arch.hvm.hvm_io.msix_unmask_address = 0;
+-    if ( msixtbl_write(v, ctrl_address, 4, 0) != X86EMUL_OKAY )
++    if ( msixtbl_write(v, ctrl_address, 4, 0, true) != X86EMUL_OKAY )
+         gdprintk(XENLOG_WARNING, "MSI-X write completion failure\n");
+ }
+ 
+-- 
+2.37.3
+

--- a/patch-msix-0002-x86-msi-Allow-writes-to-registers-on-the-same-page-a.patch
+++ b/patch-msix-0002-x86-msi-Allow-writes-to-registers-on-the-same-page-a.patch
@@ -1,0 +1,238 @@
+From 69dc24d5ac59e058ae695065f6a42196f114b043 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 14 Nov 2022 15:50:46 +0100
+Subject: [PATCH 2/2] x86/msi: Allow writes to registers on the same page as
+ MSI-X table
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some devices (notably Intel Wifi 6 AX210 card) keep auxiliary registers
+on the same page as MSI-X table. Device model (especially one in
+stubdomain) cannot really handle those, as direct writes to that page is
+refused (page is on mmio_ro_ranges list). Instead, add internal ioreq
+server that handle those writes.
+
+This may be also used to read Pending Bit Array, if it lives on the same
+page, making QEMU not needing /dev/mem access at all (especially helpful
+with lockdown enabled in dom0). If PBA lives on another page, it can be
+(and will be) mapped to the guest directly.
+If PBA lives on the same page, forbid writes. Technically, writes outside
+of PBA could be allowed, but at this moment the precise location of PBA
+isn't saved.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ xen/arch/x86/hvm/vmsi.c        | 135 +++++++++++++++++++++++++++++++++
+ xen/arch/x86/include/asm/msi.h |   1 +
+ xen/arch/x86/msi.c             |  21 +++++
+ 3 files changed, 157 insertions(+)
+
+diff --git a/xen/arch/x86/hvm/vmsi.c b/xen/arch/x86/hvm/vmsi.c
+index ba4cf46dfe91..57cfcf70741e 100644
+--- a/xen/arch/x86/hvm/vmsi.c
++++ b/xen/arch/x86/hvm/vmsi.c
+@@ -428,6 +428,133 @@ static const struct hvm_io_ops msixtbl_mmio_ops = {
+     .write = _msixtbl_write,
+ };
+ 
++static void __iomem *msixtbl_page_handler_get_hwaddr(
++        const struct vcpu *v,
++        uint64_t address,
++        bool write)
++{
++    struct domain *d = v->domain;
++    struct pci_dev *pdev = NULL;
++    struct msixtbl_entry *entry;
++    void __iomem *ret = NULL;
++    uint64_t table_end_addr;
++
++    rcu_read_lock(&msixtbl_rcu_lock);
++    /*
++     * Check if it's on the same page as the end of the MSI-X table, but
++     * outside of the table itself.
++     */
++    list_for_each_entry( entry, &d->arch.hvm.msixtbl_list, list )
++        if ( PFN_DOWN(address) == PFN_DOWN(entry->gtable + entry->table_len) &&
++             address >= entry->gtable + entry->table_len )
++        {
++            pdev = entry->pdev;
++            break;
++        }
++    rcu_read_unlock(&msixtbl_rcu_lock);
++
++    if ( !pdev )
++        return NULL;
++
++    ASSERT( pdev->msix );
++
++    table_end_addr = (pdev->msix->table.first << PAGE_SHIFT) +
++        pdev->msix->nr_entries * PCI_MSIX_ENTRY_SIZE;
++    ASSERT( PFN_DOWN(table_end_addr) == pdev->msix->table.last );
++
++    /* If PBA lives on the same page too, forbid writes. */
++    if ( write && pdev->msix->table.last == pdev->msix->pba.first )
++        return NULL;
++
++    if ( pdev->msix->last_table_page )
++        ret = pdev->msix->last_table_page + (address & (PAGE_SIZE - 1));
++    else
++        gdprintk(XENLOG_WARNING,
++                 "MSI-X last_table_page not initialized for %04x:%02x:%02x.%u\n",
++                 pdev->seg,
++                 pdev->bus,
++                 PCI_SLOT(pdev->devfn),
++                 PCI_FUNC(pdev->devfn));
++
++    return ret;
++}
++
++static bool cf_check msixtbl_page_accept(
++        const struct hvm_io_handler *handler, const ioreq_t *r)
++{
++    unsigned long addr = r->addr;
++
++    ASSERT( r->type == IOREQ_TYPE_COPY );
++
++    return msixtbl_page_handler_get_hwaddr(
++            current, addr, r->dir == IOREQ_WRITE);
++}
++
++static int cf_check msixtbl_page_read(
++        const struct hvm_io_handler *handler,
++        uint64_t address, uint32_t len, uint64_t *pval)
++{
++    void __iomem *hwaddr = msixtbl_page_handler_get_hwaddr(
++            current, address, false);
++
++    if ( !hwaddr )
++        return X86EMUL_UNHANDLEABLE;
++
++    switch ( len ) {
++        case 1:
++            *pval = readb(hwaddr);
++            break;
++        case 2:
++            *pval = readw(hwaddr);
++            break;
++        case 4:
++            *pval = readl(hwaddr);
++            break;
++        case 8:
++            *pval = readq(hwaddr);
++            break;
++        default:
++            return X86EMUL_UNHANDLEABLE;
++    }
++    return X86EMUL_OKAY;
++}
++
++static int cf_check msixtbl_page_write(
++        const struct hvm_io_handler *handler,
++        uint64_t address, uint32_t len, uint64_t val)
++{
++    void __iomem *hwaddr = msixtbl_page_handler_get_hwaddr(
++            current, address, true);
++
++    if ( !hwaddr )
++        return X86EMUL_UNHANDLEABLE;
++
++    switch ( len ) {
++        case 1:
++            writeb(val, hwaddr);
++            break;
++        case 2:
++            writew(val, hwaddr);
++            break;
++        case 4:
++            writel(val, hwaddr);
++            break;
++        case 8:
++            writeq(val, hwaddr);
++            break;
++        default:
++            return X86EMUL_UNHANDLEABLE;
++    }
++    return X86EMUL_OKAY;
++
++}
++
++static const struct hvm_io_ops msixtbl_mmio_page_ops = {
++    .accept = msixtbl_page_accept,
++    .read = msixtbl_page_read,
++    .write = msixtbl_page_write,
++};
++
+ static void add_msixtbl_entry(struct domain *d,
+                               struct pci_dev *pdev,
+                               uint64_t gtable,
+@@ -583,6 +710,14 @@ void msixtbl_init(struct domain *d)
+         handler->type = IOREQ_TYPE_COPY;
+         handler->ops = &msixtbl_mmio_ops;
+     }
++
++    /* passthrough access to other registers on the same page */
++    handler = hvm_next_io_handler(d);
++    if ( handler )
++    {
++        handler->type = IOREQ_TYPE_COPY;
++        handler->ops = &msixtbl_mmio_page_ops;
++    }
+ }
+ 
+ void msixtbl_pt_cleanup(struct domain *d)
+diff --git a/xen/arch/x86/include/asm/msi.h b/xen/arch/x86/include/asm/msi.h
+index fe670895eed2..d4287140f04c 100644
+--- a/xen/arch/x86/include/asm/msi.h
++++ b/xen/arch/x86/include/asm/msi.h
+@@ -236,6 +236,7 @@ struct arch_msix {
+     } table, pba;
+     int table_refcnt[MAX_MSIX_TABLE_PAGES];
+     int table_idx[MAX_MSIX_TABLE_PAGES];
++    void __iomem *last_table_page;
+     spinlock_t table_lock;
+     bool host_maskall, guest_maskall;
+     domid_t warned;
+diff --git a/xen/arch/x86/msi.c b/xen/arch/x86/msi.c
+index d0bf63df1def..e7fe41f424d8 100644
+--- a/xen/arch/x86/msi.c
++++ b/xen/arch/x86/msi.c
+@@ -961,6 +961,21 @@ static int msix_capability_init(struct pci_dev *dev,
+                 domain_crash(d);
+             /* XXX How to deal with existing mappings? */
+         }
++
++        /*
++         * If the MSI-X table doesn't span full page(s), map the last page for
++         * passthrough accesses.
++         */
++        if ( (msix->nr_entries * PCI_MSIX_ENTRY_SIZE) & (PAGE_SIZE - 1) )
++        {
++            uint64_t entry_paddr = table_paddr + msix->nr_entries * PCI_MSIX_ENTRY_SIZE;
++            int idx = msix_get_fixmap(msix, table_paddr, entry_paddr);
++
++            if ( idx >= 0 )
++                msix->last_table_page = fix_to_virt(idx);
++            else
++                gprintk(XENLOG_ERR, "Failed to map last MSI-X table page: %d\n", idx);
++        }
+     }
+     WARN_ON(msix->table.first != (table_paddr >> PAGE_SHIFT));
+     ++msix->used_entries;
+@@ -1090,6 +1105,12 @@ static void _pci_cleanup_msix(struct arch_msix *msix)
+             WARN();
+         msix->table.first = 0;
+         msix->table.last = 0;
++        if ( msix->last_table_page )
++        {
++            msix_put_fixmap(msix,
++                            virt_to_fix((unsigned long)msix->last_table_page));
++            msix->last_table_page = 0;
++        }
+ 
+         if ( rangeset_remove_range(mmio_ro_ranges, msix->pba.first,
+                                    msix->pba.last) )
+-- 
+2.37.3
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -135,21 +135,23 @@ Patch0626: 0626-Validate-EFI-memory-descriptors.patch
 Patch0627: 0627-x86-mm-Avoid-hard-coding-PAT-in-get_page_from_l1e.patch
 Patch0628: 0628-x86-mm-make-code-robust-to-future-PAT-changes.patch
 Patch0630: 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
+Patch0631: patch-msix-0001-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
+Patch0632: patch-msix-0002-x86-msi-Allow-writes-to-registers-on-the-same-page-a.patch
 
 # Intel HWP support
-Patch0631: 0631-cpufreq-Allow-restricting-to-internal-governors-only.patch
-Patch0632: 0632-cpufreq-Add-perf_freq-to-cpuinfo.patch
-Patch0633: 0633-cpufreq-Export-intel_feature_detect.patch
-Patch0634: 0634-cpufreq-Add-Hardware-P-State-HWP-driver.patch
-Patch0635: 0635-xenpm-Change-get-cpufreq-para-output-for-internal.patch
-Patch0636: 0636-cpufreq-Export-HWP-parameters-to-userspace.patch
-Patch0637: 0637-libxc-Include-hwp_para-in-definitions.patch
-Patch0638: 0638-xenpm-Print-HWP-parameters.patch
-Patch0639: 0639-xen-Add-SET_CPUFREQ_HWP-xen_sysctl_pm_op.patch
-Patch0640: 0640-libxc-Add-xc_set_cpufreq_hwp.patch
-Patch0641: 0641-xenpm-Factor-out-a-non-fatal-cpuid_parse-variant.patch
-Patch0642: 0642-xenpm-Add-set-cpufreq-hwp-subcommand.patch
-Patch0643: 0643-cpufreq-enable-HWP-by-default.patch
+Patch0633: 0631-cpufreq-Allow-restricting-to-internal-governors-only.patch
+Patch0634: 0632-cpufreq-Add-perf_freq-to-cpuinfo.patch
+Patch0635: 0633-cpufreq-Export-intel_feature_detect.patch
+Patch0636: 0634-cpufreq-Add-Hardware-P-State-HWP-driver.patch
+Patch0637: 0635-xenpm-Change-get-cpufreq-para-output-for-internal.patch
+Patch0638: 0636-cpufreq-Export-HWP-parameters-to-userspace.patch
+Patch0639: 0637-libxc-Include-hwp_para-in-definitions.patch
+Patch0641: 0638-xenpm-Print-HWP-parameters.patch
+Patch0642: 0639-xen-Add-SET_CPUFREQ_HWP-xen_sysctl_pm_op.patch
+Patch0643: 0640-libxc-Add-xc_set_cpufreq_hwp.patch
+Patch0644: 0641-xenpm-Factor-out-a-non-fatal-cpuid_parse-variant.patch
+Patch0645: 0642-xenpm-Add-set-cpufreq-hwp-subcommand.patch
+Patch0646: 0643-cpufreq-enable-HWP-by-default.patch
 
 # Qubes specific patches
 Patch1000: 1000-Do-not-access-network-during-the-build.patch


### PR DESCRIPTION
This is a rebase of #143 to Xen 4.17. Not fully tested yet.

---

Fixes QubesOS/qubes-issues#4799
Fixes QubesOS/qubes-issues#7057
Fixes QubesOS/qubes-issues#7052