### PR TITLE
Disable annobin for the hypervisor build

### DIFF
--- a/xen.spec.in
+++ b/xen.spec.in
@@ -462,6 +462,8 @@ export LDFLAGS="$LDFLAGS_SAVE"
 export CFLAGS="$CFLAGS_SAVE -Wno-error=address"
 
 %if %build_hyp
+# QUBES SPECIFIC LINE
+export CFLAGS=`echo $CFLAGS | sed -e 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-annobin-cc1//g'`
 %if %build_crosshyp
 export CFLAGS=`echo $CFLAGS | sed -e 's/-m32//g' -e 's/-march=i686//g' 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-annobin-cc1//g'`
 XEN_TARGET_ARCH=x86_64 %make_build %{?efi_flags} prefix=/usr xen CC="/usr/bin/x86_64-linux-gnu-gcc"


### PR DESCRIPTION
The .annobin.notes section gets placed at the start of xen.efi, which
(for unclear reasons) breaks booting under OVMF with "Out of resources"
error message.
The section looks like this:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .annobin.notes 0001286a  ffff82d100000000  ffff82d100000000  00000480  2**2
                  CONTENTS, READONLY