### PR TITLE
Fix guest memory corruption caused by hvmloader

### DIFF
--- a/1021-hvmloader-pci-do-not-allow-memory-relocate.patch
+++ b/1021-hvmloader-pci-do-not-allow-memory-relocate.patch
@@ -1,0 +1,30 @@
+From bc81cb8b47b2c489fbc6068dff46898167cd760b Mon Sep 17 00:00:00 2001
+Message-ID: <bc81cb8b47b2c489fbc6068dff46898167cd760b.1701370770.git.git@neowutran.ovh>
+From: Neowutran <git@neowutran.ovh>
+Date: Wed, 29 Nov 2023 20:35:02 +0100
+Subject: [PATCH] fix hvmloader relocating memory and overwritting some part of guest memory
+
+---
+ tools/firmware/hvmloader/pci.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/tools/firmware/hvmloader/pci.c b/tools/firmware/hvmloader/pci.c
+index 257a6feb..03b464da 100644
+--- a/tools/firmware/hvmloader/pci.c
++++ b/tools/firmware/hvmloader/pci.c
+@@ -118,7 +118,12 @@ void pci_setup(void)
+      * Since xend can only use qemu-traditional, I think this is the
+      * option that will have the least impact.
+      */
+-    bool allow_memory_relocate = 1;
++    /*
++     *  For QubesOS we default to 0. qemu-traditional is not used. 
++     *  Settings this parameter to 1 can result in memory corruption
++     *  in the guest when passingthrough big pci device like GPU.
++     */
++    bool allow_memory_relocate = 0;
+ 
+     BUILD_BUG_ON((typeof(*pci_devfn_decode_type))PCI_COMMAND_IO !=
+                  PCI_COMMAND_IO);
+-- 
+2.43.0

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -187,7 +187,7 @@ Patch1016: 1016-gnttab-disable-grant-tables-v2-by-default.patch
 Patch1017: 1017-Disable-TSX-by-default.patch
 Patch1018: 1018-Fix-IGD-passthrough-with-linux-stubdomain.patch
 Patch1019: 1019-Use-Linux-s-PAT.patch
-Patch1020: 1021-hvmloader-pci-do-not-allow-memory-relocate.patch
+Patch1021: 1021-hvmloader-pci-do-not-allow-memory-relocate.patch
 
 # Reproducible builds
 Patch1100: 1100-Define-build-dates-time-based-on-SOURCE_DATE_EPOCH.patch

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -187,6 +187,7 @@ Patch1016: 1016-gnttab-disable-grant-tables-v2-by-default.patch
 Patch1017: 1017-Disable-TSX-by-default.patch
 Patch1018: 1018-Fix-IGD-passthrough-with-linux-stubdomain.patch
 Patch1019: 1019-Use-Linux-s-PAT.patch
+Patch1020: 1021-hvmloader-pci-do-not-allow-memory-relocate.patch
 
 # Reproducible builds
 Patch1100: 1100-Define-build-dates-time-based-on-SOURCE_DATE_EPOCH.patch


### PR DESCRIPTION
The xen hvmloader is relocating memory and overwritting some part of guest memory. 

It seem to be a known issue in xen since the behavior is documented in the source code, so idk if it should be reported to the xen project. 

I tested this patch on my setup for a few days, saw no issues yet, and it fixed https://github.com/QubesOS/qubes-issues/issues/4321 
