### PR TITLE
Extend IGD check

### DIFF
--- a/0654-libxl-extend-IGD-check.patch
+++ b/0654-libxl-extend-IGD-check.patch
@@ -1,0 +1,34 @@
+From 7e76d6cc408d11fe7ed9ba4792d063c01646ed3b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Thu, 28 Nov 2024 04:51:44 +0100
+Subject: [PATCH] libxl: extend IGD check
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Consider also "Display controller" an IGD, not only "VGA compatible
+controller". Specifically, IGD on Raptor Lake has 0x038000 class, not
+0x030000.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_pci.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/libs/light/libxl_pci.c b/tools/libs/light/libxl_pci.c
+index 35e3e1360423..5be9b8239567 100644
+--- a/tools/libs/light/libxl_pci.c
++++ b/tools/libs/light/libxl_pci.c
+@@ -635,7 +635,7 @@ bool libxl__is_igd_vga_passthru(libxl__gc *gc,
+ 
+         if (sysfs_dev_get_class(gc, pci, &class))
+             continue;
+-        if (class == 0x030000)
++        if (class == 0x030000 || class == 0x038000)
+             return true;
+     }
+ 
+-- 
+2.46.0
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -132,8 +132,6 @@ Patch0622: 0622-x86-mm-make-code-robust-to-future-PAT-changes.patch
 Patch0623: 0623-Drop-ELF-notes-from-non-EFI-binary-too.patch
 Patch0624: 0624-xenpm-Factor-out-a-non-fatal-cpuid_parse-variant.patch
 
-Patch0653: 0653-python-avoid-conflicting-_FORTIFY_SOURCE-values.patch
-
 # S0ix support
 Patch0625: 0625-x86-idle-Get-PC-8.10-counters-for-Tiger-and-Alder-La.patch
 Patch0626: 0626-x86-ACPI-Ignore-entries-marked-as-unusable-when-pars.patch
@@ -142,6 +140,8 @@ Patch0628: 0628-x86-mwait-idle-Use-ACPI-for-CPUs-without-hardcoded-C.patch
 Patch0629: 0629-libxl_pci-Pass-power_mgmt-via-QMP.patch
 
 Patch0630: 0630-tools-xg-increase-LZMA_BLOCK_SIZE-for-uncompressing-.patch
+
+Patch0653: 0653-python-avoid-conflicting-_FORTIFY_SOURCE-values.patch
 
 # Qubes specific patches
 Patch1000: 1000-Do-not-access-network-during-the-build.patch

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -142,6 +142,7 @@ Patch0629: 0629-libxl_pci-Pass-power_mgmt-via-QMP.patch
 Patch0630: 0630-tools-xg-increase-LZMA_BLOCK_SIZE-for-uncompressing-.patch
 
 Patch0653: 0653-python-avoid-conflicting-_FORTIFY_SOURCE-values.patch
+Patch0654: 0654-libxl-extend-IGD-check.patch
 
 # Qubes specific patches
 Patch1000: 1000-Do-not-access-network-during-the-build.patch


### PR DESCRIPTION
Consider also "Display controller" an IGD, not only "VGA compatible 
controller". Specifically, IGD on Raptor Lake has 0x038000 class, not 
0x030000.