### PR TITLE
Backport IOMMU related fixed for AMD

### DIFF
--- a/0323-x86-io-apic-fix-directed-EOI-when-using-AMD-Vi-inter.patch
+++ b/0323-x86-io-apic-fix-directed-EOI-when-using-AMD-Vi-inter.patch
@@ -1,0 +1,166 @@
+From 2dece3446ffb221ec387f1f668408c1705bcd5ac Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 31 Oct 2024 09:57:13 +0100
+Subject: [PATCH] x86/io-apic: fix directed EOI when using AMD-Vi interrupt
+ remapping
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When using AMD-Vi interrupt remapping the vector field in the IO-APIC RTE is
+repurposed to contain part of the offset into the remapping table.  Previous to
+2ca9fbd739b8 Xen had logic so that the offset into the interrupt remapping
+table would match the vector.  Such logic was mandatory for end of interrupt to
+work, since the vector field (even when not containing a vector) is used by the
+IO-APIC to find for which pin the EOI must be performed.
+
+A simple solution wold be to read the IO-APIC RTE each time an EOI is to be
+performed, so the raw value of the vector field can be obtained.  However
+that's likely to perform poorly.  Instead introduce a cache to store the
+EOI handles when using interrupt remapping, so that the IO-APIC driver can
+translate pins into EOI handles without having to read the IO-APIC RTE entry.
+Note that to simplify the logic such cache is used unconditionally when
+interrupt remapping is enabled, even if strictly it would only be required
+for AMD-Vi.
+
+Reported-by: Willi Junga <xenproject@ymy.be>
+Suggested-by: David Woodhouse <dwmw@amazon.co.uk>
+Fixes: 2ca9fbd739b8 ('AMD IOMMU: allocate IRTE entries instead of using a static mapping')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Tested-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/io_apic.c | 76 +++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 71 insertions(+), 5 deletions(-)
+
+diff --git a/xen/arch/x86/io_apic.c b/xen/arch/x86/io_apic.c
+index 6f4b04878d2c..9b5ee131d02d 100644
+--- a/xen/arch/x86/io_apic.c
++++ b/xen/arch/x86/io_apic.c
+@@ -29,6 +29,7 @@
+ #include <xen/acpi.h>
+ #include <xen/keyhandler.h>
+ #include <xen/softirq.h>
++#include <xen/xmalloc.h>
+ 
+ #include <asm/hpet.h>
+ #include <asm/mc146818rtc.h>
+@@ -71,6 +72,24 @@ static int apic_pin_2_gsi_irq(int apic, int pin);
+ 
+ static vmask_t *__read_mostly vector_map[MAX_IO_APICS];
+ 
++/*
++ * Store the EOI handle when using interrupt remapping.
++ *
++ * If using AMD-Vi interrupt remapping the IO-APIC redirection entry remapped
++ * format repurposes the vector field to store the offset into the Interrupt
++ * Remap table.  This breaks directed EOI, as the CPU vector no longer matches
++ * the contents of the RTE vector field.  Add a translation cache so that
++ * directed EOI uses the value in the RTE vector field when interrupt remapping
++ * is enabled.
++ *
++ * Intel VT-d Xen code still stores the CPU vector in the RTE vector field when
++ * using the remapped format, but use the translation cache uniformly in order
++ * to avoid extra logic to differentiate between VT-d and AMD-Vi.
++ *
++ * The matrix is accessed as [#io-apic][#pin].
++ */
++static uint8_t **__ro_after_init io_apic_pin_eoi;
++
+ static void share_vector_maps(unsigned int src, unsigned int dst)
+ {
+     unsigned int pin;
+@@ -273,6 +292,17 @@ void __ioapic_write_entry(
+     {
+         __io_apic_write(apic, 0x11 + 2 * pin, eu.w2);
+         __io_apic_write(apic, 0x10 + 2 * pin, eu.w1);
++        /*
++         * Might be called before io_apic_pin_eoi is allocated.  Entry will be
++         * initialized to the RTE value once the cache is allocated.
++         *
++         * The vector field is only cached for raw RTE writes when using IR.
++         * In that case the vector field might have been repurposed to store
++         * something different than the CPU vector, and hence need to be cached
++         * for performing EOI.
++         */
++        if ( io_apic_pin_eoi )
++            io_apic_pin_eoi[apic][pin] = e.vector;
+     }
+     else
+         iommu_update_ire_from_apic(apic, pin, e.raw);
+@@ -288,18 +318,36 @@ static void ioapic_write_entry(
+     spin_unlock_irqrestore(&ioapic_lock, flags);
+ }
+ 
+-/* EOI an IO-APIC entry.  Vector may be -1, indicating that it should be
++/*
++ * EOI an IO-APIC entry.  Vector may be -1, indicating that it should be
+  * worked out using the pin.  This function expects that the ioapic_lock is
+  * being held, and interrupts are disabled (or there is a good reason not
+  * to), and that if both pin and vector are passed, that they refer to the
+- * same redirection entry in the IO-APIC. */
++ * same redirection entry in the IO-APIC.
++ *
++ * If using Interrupt Remapping the vector is always ignored because the RTE
++ * remapping format might have repurposed the vector field and a cached value
++ * of the EOI handle to use is obtained based on the provided apic and pin
++ * values.
++ */
+ static void __io_apic_eoi(unsigned int apic, unsigned int vector, unsigned int pin)
+ {
+     /* Prefer the use of the EOI register if available */
+     if ( ioapic_has_eoi_reg(apic) )
+     {
+-        /* If vector is unknown, read it from the IO-APIC */
+-        if ( vector == IRQ_VECTOR_UNASSIGNED )
++        if ( io_apic_pin_eoi )
++            /*
++             * If the EOI handle is cached use it. When using AMD-Vi IR the CPU
++             * vector no longer matches the vector field in the RTE, because
++             * the RTE remapping format repurposes the field.
++             *
++             * The value in the RTE vector field must always be used to signal
++             * which RTE to EOI, hence use the cached value which always
++             * mirrors the contents of the raw RTE vector field.
++             */
++            vector = io_apic_pin_eoi[apic][pin];
++        else if ( vector == IRQ_VECTOR_UNASSIGNED )
++             /* If vector is unknown, read it from the IO-APIC */
+             vector = __ioapic_read_entry(apic, pin, true).vector;
+ 
+         *(IO_APIC_BASE(apic)+16) = vector;
+@@ -1298,12 +1346,30 @@ void __init enable_IO_APIC(void)
+             vector_map[apic] = vector_map[0];
+     }
+ 
++    if ( iommu_intremap != iommu_intremap_off )
++    {
++        io_apic_pin_eoi = xmalloc_array(typeof(*io_apic_pin_eoi), nr_ioapics);
++        BUG_ON(!io_apic_pin_eoi);
++    }
++
+     for(apic = 0; apic < nr_ioapics; apic++) {
+         int pin;
+-        /* See if any of the pins is in ExtINT mode */
++
++        if ( io_apic_pin_eoi )
++        {
++            io_apic_pin_eoi[apic] = xmalloc_array(typeof(**io_apic_pin_eoi),
++                                                   nr_ioapic_entries[apic]);
++            BUG_ON(!io_apic_pin_eoi[apic]);
++        }
++
++        /* See if any of the pins is in ExtINT mode and cache EOI handle */
+         for (pin = 0; pin < nr_ioapic_entries[apic]; pin++) {
+             struct IO_APIC_route_entry entry = ioapic_read_entry(apic, pin, false);
+ 
++            if ( io_apic_pin_eoi )
++                io_apic_pin_eoi[apic][pin] =
++                    ioapic_read_entry(apic, pin, true).vector;
++
+             /* If the interrupt line is enabled and in ExtInt mode
+              * I have found the pin where the i8259 is connected.
+              */
+-- 
+2.48.0
+

--- a/0324-x86-io-apic-prevent-early-exit-from-i8259-loop-detec.patch
+++ b/0324-x86-io-apic-prevent-early-exit-from-i8259-loop-detec.patch
@@ -1,0 +1,81 @@
+From c6e9854003691c025011e732f72e12f67559ac85 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Mon, 16 Dec 2024 19:33:29 +0100
+Subject: [PATCH] x86/io-apic: prevent early exit from i8259 loop detection
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Avoid exiting early from the loop when a pin that could be connected to the
+i8259 is found, as such early exit would leave the EOI handler translation
+array only partially allocated and/or initialized.
+
+Otherwise on systems with multiple IO-APICs and an unmasked ExtINT pin on
+any IO-APIC that's no the last one the following NULL pointer dereference
+triggers:
+
+(XEN) Enabling APIC mode.  Using 2 I/O APICs
+(XEN) ----[ Xen-4.20-unstable  x86_64  debug=y  Not tainted ]----
+(XEN) CPU:    0
+(XEN) RIP:    e008:[<ffff82d040328046>] __ioapic_write_entry+0x83/0x95
+[...]
+(XEN) Xen call trace:
+(XEN)    [<ffff82d040328046>] R __ioapic_write_entry+0x83/0x95
+(XEN)    [<ffff82d04027464b>] F amd_iommu_ioapic_update_ire+0x1ea/0x273
+(XEN)    [<ffff82d0402755a1>] F iommu_update_ire_from_apic+0xa/0xc
+(XEN)    [<ffff82d040328056>] F __ioapic_write_entry+0x93/0x95
+(XEN)    [<ffff82d0403283c1>] F arch/x86/io_apic.c#clear_IO_APIC_pin+0x7c/0x10e
+(XEN)    [<ffff82d040328480>] F arch/x86/io_apic.c#clear_IO_APIC+0x2d/0x61
+(XEN)    [<ffff82d0404448b7>] F enable_IO_APIC+0x2e3/0x34f
+(XEN)    [<ffff82d04044c9b0>] F smp_prepare_cpus+0x254/0x27a
+(XEN)    [<ffff82d04044bec2>] F __start_xen+0x1ce1/0x23ae
+(XEN)    [<ffff82d0402033ae>] F __high_start+0x8e/0x90
+(XEN)
+(XEN) Pagetable walk from 0000000000000000:
+(XEN)  L4[0x000] = 000000007dbfd063 ffffffffffffffff
+(XEN)  L3[0x000] = 000000007dbfa063 ffffffffffffffff
+(XEN)  L2[0x000] = 000000007dbcc063 ffffffffffffffff
+(XEN)  L1[0x000] = 0000000000000000 ffffffffffffffff
+(XEN)
+(XEN) ****************************************
+(XEN) Panic on CPU 0:
+(XEN) FATAL PAGE FAULT
+(XEN) [error_code=0002]
+(XEN) Faulting linear address: 0000000000000000
+(XEN) ****************************************
+(XEN)
+(XEN) Reboot in five seconds...
+
+Reported-by: Sergii Dmytruk <sergii.dmytruk@3mdeb.com>
+Fixes: 86001b3970fe ('x86/io-apic: fix directed EOI when using AMD-Vi interrupt remapping')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/io_apic.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/xen/arch/x86/io_apic.c b/xen/arch/x86/io_apic.c
+index 9b5ee131d02d..9071dfba5a5b 100644
+--- a/xen/arch/x86/io_apic.c
++++ b/xen/arch/x86/io_apic.c
+@@ -1373,14 +1373,14 @@ void __init enable_IO_APIC(void)
+             /* If the interrupt line is enabled and in ExtInt mode
+              * I have found the pin where the i8259 is connected.
+              */
+-            if ((entry.mask == 0) && (entry.delivery_mode == dest_ExtINT)) {
++            if ( ioapic_i8259.pin == -1 && entry.mask == 0 &&
++                 entry.delivery_mode == dest_ExtINT )
++            {
+                 ioapic_i8259.apic = apic;
+                 ioapic_i8259.pin  = pin;
+-                goto found_i8259;
+             }
+         }
+     }
+- found_i8259:
+     /* Look to see what if the MP table has reported the ExtINT */
+     /* If we could not find the appropriate pin by looking at the ioapic
+      * the i8259 probably is not connected the ioapic but give the
+-- 
+2.48.0
+

--- a/0325-iommu-amd-vi-do-not-error-if-device-referenced-in-IV.patch
+++ b/0325-iommu-amd-vi-do-not-error-if-device-referenced-in-IV.patch
@@ -1,0 +1,50 @@
+From 2defb544900a11f93104ac68d2f8beba89d4bd02 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Roger=20Pau=20Monn=C3=A9?= <roger.pau@citrix.com>
+Date: Tue, 15 Oct 2024 14:23:59 +0200
+Subject: [PATCH] iommu/amd-vi: do not error if device referenced in IVMD is
+ not behind any IOMMU
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+IVMD table contains restrictions about memory which must be mandatory assigned
+to devices (and which permissions it should use), or memory that should be
+never accessible to devices.
+
+Some hardware however contains ranges in IVMD that reference devices outside of
+the IVHD tables (in other words, devices not behind any IOMMU).  Such mismatch
+will cause Xen to fail in register_range_for_device(), ultimately leading to
+the IOMMU being disabled, and Xen crashing as x2APIC support might be already
+enabled and relying on the IOMMU functionality.
+
+Relax IVMD parsing: allow IVMD blocks to reference devices not assigned to any
+IOMMU.  It's impossible for Xen to fulfill the requirement in the IVMD block if
+the device is not behind any IOMMU, but it's no worse than booting without
+IOMMU support, and thus not parsing ACPI IVRS in the first place.
+
+Reported-by: Willi Junga <xenproject@ymy.be>
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/drivers/passthrough/amd/iommu_acpi.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/xen/drivers/passthrough/amd/iommu_acpi.c b/xen/drivers/passthrough/amd/iommu_acpi.c
+index 3f5508eba049..c416120326c9 100644
+--- a/xen/drivers/passthrough/amd/iommu_acpi.c
++++ b/xen/drivers/passthrough/amd/iommu_acpi.c
+@@ -248,8 +248,9 @@ static int __init register_range_for_device(
+     iommu = find_iommu_for_device(seg, bdf);
+     if ( !iommu )
+     {
+-        AMD_IOMMU_ERROR("IVMD: no IOMMU for Dev_Id %#x\n", bdf);
+-        return -ENODEV;
++        AMD_IOMMU_WARN("IVMD: no IOMMU for device %pp - ignoring constrain\n",
++                       &PCI_SBDF(seg, bdf));
++        return 0;
+     }
+     req = ivrs_mappings[bdf].dte_requestor_id;
+ 
+-- 
+2.48.0
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -113,6 +113,9 @@ Patch0319: 0319-drivers-char-Use-sub-page-ro-API-to-make-just-xhci-d.patch
 Patch0320: 0320-Simplified-version-of-don-t-expose-XENFEAT_hvm_pirqs.patch
 Patch0321: 0321-x86-x2APIC-correct-cluster-tracking-upon-CPUs-going-.patch
 Patch0322: 0322-xen-spinlock-Fix-UBSAN-load-of-address-with-insuffic.patch
+Patch0323: 0323-x86-io-apic-fix-directed-EOI-when-using-AMD-Vi-inter.patch
+Patch0324: 0324-x86-io-apic-prevent-early-exit-from-i8259-loop-detec.patch
+Patch0325: 0325-iommu-amd-vi-do-not-error-if-device-referenced-in-IV.patch
 
 # Security fixes
 Patch0500: 0500-xsa464.patch


### PR DESCRIPTION
This fixes touchpad and USB interrupts on AMD Framework, and also avoid
disabling IOMMU (and then crashing) on systems with slightly overly
broad IVMD blocks (that include devices not behind any IOMMU, or even
non-existent ones).

Fixes https://github.com/QubesOS/qubes-issues/issues/8734