### PR TITLE
Add patch to support Meteor Lake C-states

### DIFF
--- a/0633-x86-idle-Implement-support-for-Meteor-Lake.patch
+++ b/0633-x86-idle-Implement-support-for-Meteor-Lake.patch
@@ -1,0 +1,36 @@
+From ba9831dbf8eb15f30b29a752c4c379977587a2cf Mon Sep 17 00:00:00 2001
+From: Alex XZ Cypher Zero <me@alex0.net>
+Date: Mon, 7 Jul 2025 19:56:32 +0100
+Subject: [PATCH 1/1] x86/idle: Implement support for Meteor Lake
+
+Adds support for Meteor Lake C-states. As the spec is identical to Alder Lake as per the Intel specs, I've reused the Alder Lake codepath.
+
+Signed-off-by: Alex XZ Cypher Zero <me@alex0.net>
+---
+ xen/arch/x86/cpu/mwait-idle.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/xen/arch/x86/cpu/mwait-idle.c b/xen/arch/x86/cpu/mwait-idle.c
+index ae69871171..2c5356991b 100644
+--- a/xen/arch/x86/cpu/mwait-idle.c
++++ b/xen/arch/x86/cpu/mwait-idle.c
+@@ -1180,6 +1180,8 @@ static const struct x86_cpu_id intel_idle_ids[] __initconstrel = {
+ 	ICPU(ICELAKE_D,			icx),
+ 	ICPU(ALDERLAKE,			adl),
+ 	ICPU(ALDERLAKE_L,		adl_l),
++	ICPU(METEORLAKE,		adl),
++	ICPU(METEORLAKE_L,		adl_l),
+ 	ICPU(SAPPHIRERAPIDS_X,		spr),
+ 	ICPU(XEON_PHI_KNL,		knl),
+ 	ICPU(XEON_PHI_KNM,		knl),
+@@ -1420,6 +1422,8 @@ static void __init mwait_idle_state_table_update(void)
+ 		break;
+ 	case INTEL_FAM6_ALDERLAKE:
+ 	case INTEL_FAM6_ALDERLAKE_L:
++	case INTEL_FAM6_METEORLAKE:
++	case INTEL_FAM6_METEORLAKE_L:
+ 		adl_idle_state_table_update();
+ 		break;
+ 	}
+-- 
+2.50.0

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -152,6 +152,7 @@ Patch0620: 0620-Validate-EFI-memory-descriptors.patch
 Patch0621: 0621-x86-mm-make-code-robust-to-future-PAT-changes.patch
 Patch0622: 0622-Drop-ELF-notes-from-non-EFI-binary-too.patch
 Patch0623: 0623-xenpm-Factor-out-a-non-fatal-cpuid_parse-variant.patch
+Patch0633: 0633-x86-idle-Implement-support-for-Meteor-Lake.patch
 
 # S0ix support
 Patch0624: 0624-x86-idle-Get-PC-8.10-counters-for-Tiger-and-Alder-La.patch


### PR DESCRIPTION
Adds support for Meteor Lake C-states. As the spec is identical to Alder Lake as per the Intel specs, I've reused the Alder Lake codepath. This change has been sent to the xen-devel mailing list.