### PR TITLE
Fix ArchLinux dependency to iproute2

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -9,7 +9,7 @@ pkgdesc="Xen is a virtual machine monitor"
 arch=("x86_64")
 url="http://qubes-os.org/"
 license=('GPL')
-depends=(bridge-utils python-lxml libutil-linux lzo libsystemd yajl)
+depends=(iproute2 python-lxml libutil-linux lzo libsystemd yajl)
 makedepends=(wget make gcc patch git iasl pkg-config openssl pixman python-setuptools)
 provides=('xen-qubes-vm-essentials')
 


### PR DESCRIPTION
bridge-utils is now deprecated for ArchLinux.
Fixes https://github.com/QubesOS/qubes-issues/issues/10539