### PR TITLE
Backport fixes for timers after S3 suspend

### DIFF
--- a/0303-x86-S3-restore-MCE-APs-init.patch
+++ b/0303-x86-S3-restore-MCE-APs-init.patch
@@ -1,0 +1,52 @@
+From 5ebd4dd14118e4eb24f1d409a7ca3773f77e7e41 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Tue, 24 Mar 2026 12:05:42 +0100
+Subject: [PATCH] x86/S3: restore MCE (APs) init
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+MCE init for APs was broken when CPU feature re-checking was added. At the
+same time make sure we don't bypass setup_doitm() (and whatever else may
+be added to the bottom of identify_cpu()).
+
+Fixes: bb502a8ca592 ("x86: check feature flags after resume")
+Reported-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Tested-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Acked-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/arch/x86/cpu/common.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/xen/arch/x86/cpu/common.c b/xen/arch/x86/cpu/common.c
+index 5d0523a78b52..5ac76897ae47 100644
+--- a/xen/arch/x86/cpu/common.c
++++ b/xen/arch/x86/cpu/common.c
+@@ -642,16 +642,20 @@ void identify_cpu(struct cpuinfo_x86 *c)
+ 			       smp_processor_id());
+ 	}
+ 
+-	if (system_state == SYS_STATE_resume)
+-		return;
++	if (system_state == SYS_STATE_resume) {
++		unsigned int cpu = smp_processor_id();
+ 
++		/* The BSP has this done right from enter_state(). */
++		if (cpu)
++			mcheck_init(&cpu_data[cpu], false);
++	}
+ 	/*
+ 	 * On SMP, boot_cpu_data holds the common feature set between
+ 	 * all CPUs; so make sure that we indicate which features are
+ 	 * common between the CPUs.  The first time this routine gets
+ 	 * executed, c == &boot_cpu_data.
+ 	 */
+-	if ( c != &boot_cpu_data ) {
++	else if (c != &boot_cpu_data) {
+ 		/* AND the already accumulated flags with these */
+ 		for ( i = 0 ; i < NCAPINTS ; i++ )
+ 			boot_cpu_data.x86_capability[i] &= c->x86_capability[i];
+-- 
+2.53.0
+

--- a/0304-x86-time-do-not-kill-calibration-timer-on-suspend.patch
+++ b/0304-x86-time-do-not-kill-calibration-timer-on-suspend.patch
@@ -1,0 +1,37 @@
+From 605e7ba0d7b44eb0c4bd57c3d109e82b73f872d5 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Fri, 10 Apr 2026 10:55:04 +0200
+Subject: [PATCH] x86/time: do not kill calibration timer on suspend
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A killed timer will ignore further set_timer() calls, and hence won't be
+re-armed unless it's initialized again.  Use stop_timer() instead of
+kill_timer() in time_suspend(), so that the set_timer() call in
+time_resume() successfully re-arms the timer.  Otherwise time calibration
+is no longer scheduled (and executed) after resuming from S3 suspend.
+
+Fixes: 6d90db1a2ca1 ("x86: rendezvous-based local time calibration")
+Reported-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/arch/x86/time.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xen/arch/x86/time.c b/xen/arch/x86/time.c
+index e98fe78b5b0e..006a2c1761d8 100644
+--- a/xen/arch/x86/time.c
++++ b/xen/arch/x86/time.c
+@@ -2726,7 +2726,7 @@ int time_suspend(void)
+     {
+         cmos_utc_offset = -get_wallclock_time();
+         cmos_utc_offset += get_sec();
+-        kill_timer(&calibration_timer);
++        stop_timer(&calibration_timer);
+ 
+         /* Sync platform timer stamps. */
+         platform_time_calibration();
+-- 
+2.53.0
+

--- a/xen.spec.in
+++ b/xen.spec.in
@@ -100,6 +100,8 @@ Patch0203: 0203-xen.efi.build.patch
 Patch0300: 0300-xen-list-add-LIST_HEAD_RO_AFTER_INIT.patch
 Patch0301: 0301-x86-mm-add-API-for-marking-only-part-of-a-MMIO-page-.patch
 Patch0302: 0302-drivers-char-Use-sub-page-ro-API-to-make-just-xhci-d.patch
+Patch0303: 0303-x86-S3-restore-MCE-APs-init.patch
+Patch0304: 0304-x86-time-do-not-kill-calibration-timer-on-suspend.patch
 
 # Security fixes (500+)
 Patch0500: 0500-xsa480.patch


### PR DESCRIPTION
This makes performance after resume remain at normal level, instead of
degrading over time. But it looks like the fix may still be just a
workaround hiding the actual issue, see:
https://lore.kernel.org/xen-devel/adjUcmzVrwxEcn4m@mail-itl/T/#t

Fixes QubesOS/qubes-issues#10616